### PR TITLE
[CMAT-21] fix: 직무별 추천 컨텐츠 조회 api 수정

### DIFF
--- a/src/main/java/UMC/career_mate/domain/content/controller/ContentController.java
+++ b/src/main/java/UMC/career_mate/domain/content/controller/ContentController.java
@@ -3,17 +3,9 @@ package UMC.career_mate.domain.content.controller;
 import UMC.career_mate.domain.content.dto.request.ContentRequestDTO;
 import UMC.career_mate.domain.content.dto.response.ContentResponseDTO;
 import UMC.career_mate.domain.content.service.ContentService;
-import UMC.career_mate.domain.job.Service.JobService;
-import UMC.career_mate.domain.member.Member;
-import UMC.career_mate.global.annotation.LoginMember;
 import UMC.career_mate.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,44 +15,43 @@ import java.util.List;
 @RequestMapping("/content")
 public class ContentController {
 
-    private final JobService jobService;
     private final ContentService contentService;
 
-    @PostMapping // 컨텐츠 업로드 (관리자용)
+    @PostMapping
     @Operation(
             summary = "컨텐츠 업로드 API",
             description = """
-            관리자가 api로 컨텐츠를 업로드할 때 사용합니다.
-            요청 바디에 아래 필드를 포함해야 합니다.
-            - `title`: 컨텐츠 제목 (필수)
-            - `url`: 컨텐츠 링크 (필수)
-            - `photo`: 썸네일 이미지 링크 (필수)
-            - `jobId`: 직무 ID (필수)
-            """
+                    새로운 컨텐츠를 생성합니다. (관리자용)
+                    ### 요청 예시 JSON:
+                    ```json
+                    {
+                        "title": "Spring Boot Guide",
+                        "url": "https://example.com/spring-boot",
+                        "photo": "https://example.com/image.jpg",
+                        "jobId": 1
+                    }
+                    ```
+                    """
     )
     public ApiResponse<ContentResponseDTO> uploadContent(@RequestBody ContentRequestDTO contentRequestDTO) {
         return ApiResponse.onSuccess(contentService.uploadContent(contentRequestDTO));
     }
 
-    @GetMapping // 직무별 콘텐츠 조회
+    @GetMapping
     @Operation(
             summary = "직무별 컨텐츠 조회 API",
             description = """
-        요청된 직무 ID에 따라 해당 직무의 콘텐츠를 조회합니다.
-        Query Parameters를 통해 jobid를 받고, 만약 해당 jobid가 db에 존재하지 않는다면 EJB000, 400 에러코드를 띄웁니다.
-        요청 파라미터:
-        - `jobId`: 조회할 직무 ID (필수)
-        - `page`: 페이지 번호 (기본값: 1)
-        - `size`: 페이지 크기 (기본값: 10)
-        """
+                    특정 직무 ID에 해당하는 컨텐츠를 조회합니다.
+                    Query Parameters:
+                    - `jobId`: 직무 ID (필수)
+                    - `page`: 페이지 번호 (기본값: 1)
+                    - `size`: 페이지 크기 (기본값: 10)
+                    """
     )
-    public ApiResponse<?> getContentsByJobId(@RequestParam Long jobId,
-                                             @RequestParam(defaultValue = "1") int page,
-                                             @RequestParam(defaultValue = "10") int size) {
-        // 직무 ID 검증
-        jobService.findJobById(jobId);
-
-        // 콘텐츠 조회
+    public ApiResponse<List<ContentResponseDTO>> getContentsByJobId(
+            @RequestParam Long jobId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) {
         return ApiResponse.onSuccess(contentService.getContentsByJobId(jobId, page, size));
     }
 }

--- a/src/main/java/UMC/career_mate/domain/content/controller/ContentController.java
+++ b/src/main/java/UMC/career_mate/domain/content/controller/ContentController.java
@@ -3,6 +3,7 @@ package UMC.career_mate.domain.content.controller;
 import UMC.career_mate.domain.content.dto.request.ContentRequestDTO;
 import UMC.career_mate.domain.content.dto.response.ContentResponseDTO;
 import UMC.career_mate.domain.content.service.ContentService;
+import UMC.career_mate.global.common.PageResponseDTO;
 import UMC.career_mate.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -48,7 +49,7 @@ public class ContentController {
                     - `size`: 페이지 크기 (기본값: 10)
                     """
     )
-    public ApiResponse<List<ContentResponseDTO>> getContentsByJobId(
+    public ApiResponse<PageResponseDTO<List<ContentResponseDTO>>> getContentsByJobId(
             @RequestParam Long jobId,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size) {

--- a/src/main/java/UMC/career_mate/domain/content/converter/ContentConverter.java
+++ b/src/main/java/UMC/career_mate/domain/content/converter/ContentConverter.java
@@ -1,0 +1,30 @@
+package UMC.career_mate.domain.content.converter;
+
+import UMC.career_mate.domain.content.Content;
+import UMC.career_mate.domain.content.dto.request.ContentRequestDTO;
+import UMC.career_mate.domain.content.dto.response.ContentResponseDTO;
+import UMC.career_mate.domain.job.Job;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ContentConverter {
+
+    public Content toContent(ContentRequestDTO contentRequestDTO, Job job) {
+        return Content.builder()
+                .title(contentRequestDTO.title())
+                .url(contentRequestDTO.url())
+                .photo(contentRequestDTO.photo())
+                .job(job)
+                .build();
+    }
+
+    public ContentResponseDTO toContentResponseDTO(Content content) {
+        return ContentResponseDTO.builder()
+                .id(content.getId())
+                .title(content.getTitle())
+                .url(content.getUrl())
+                .photo(content.getPhoto())
+                .jobId(content.getJob().getId())
+                .build();
+    }
+}

--- a/src/main/java/UMC/career_mate/domain/content/converter/ContentConverter.java
+++ b/src/main/java/UMC/career_mate/domain/content/converter/ContentConverter.java
@@ -4,12 +4,10 @@ import UMC.career_mate.domain.content.Content;
 import UMC.career_mate.domain.content.dto.request.ContentRequestDTO;
 import UMC.career_mate.domain.content.dto.response.ContentResponseDTO;
 import UMC.career_mate.domain.job.Job;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ContentConverter {
 
-    public Content toContent(ContentRequestDTO contentRequestDTO, Job job) {
+    public static Content toContent(ContentRequestDTO contentRequestDTO, Job job) {
         return Content.builder()
                 .title(contentRequestDTO.title())
                 .url(contentRequestDTO.url())
@@ -18,7 +16,7 @@ public class ContentConverter {
                 .build();
     }
 
-    public ContentResponseDTO toContentResponseDTO(Content content) {
+    public static ContentResponseDTO toContentResponseDTO(Content content) {
         return ContentResponseDTO.builder()
                 .id(content.getId())
                 .title(content.getTitle())

--- a/src/main/java/UMC/career_mate/domain/content/dto/request/ContentRequestDTO.java
+++ b/src/main/java/UMC/career_mate/domain/content/dto/request/ContentRequestDTO.java
@@ -1,8 +1,5 @@
 package UMC.career_mate.domain.content.dto.request;
 
-import lombok.Builder;
-
-@Builder
 public record ContentRequestDTO(
         String title,
         String url,

--- a/src/main/java/UMC/career_mate/domain/content/dto/response/ContentResponseDTO.java
+++ b/src/main/java/UMC/career_mate/domain/content/dto/response/ContentResponseDTO.java
@@ -1,15 +1,13 @@
 package UMC.career_mate.domain.content.dto.response;
 
-import UMC.career_mate.domain.content.Content;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class ContentResponseDTO {
-    private Long id;
-    private String title;
-    private String url;
-    private String photo;
-    private Long jobId;
+public record ContentResponseDTO(
+        Long id,
+        String title,
+        String url,
+        String photo,
+        Long jobId
+) {
 }

--- a/src/main/java/UMC/career_mate/domain/content/dto/response/ContentResponseDTO.java
+++ b/src/main/java/UMC/career_mate/domain/content/dto/response/ContentResponseDTO.java
@@ -2,22 +2,14 @@ package UMC.career_mate.domain.content.dto.response;
 
 import UMC.career_mate.domain.content.Content;
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 @Builder
-public record ContentResponseDTO(
-        Long id,
-        String title,
-        String url,
-        String photo,
-        Long jobId
-) {
-    public static ContentResponseDTO fromEntity(Content content) {
-        return ContentResponseDTO.builder()
-                .id(content.getId())
-                .title(content.getTitle())
-                .url(content.getUrl())
-                .photo(content.getPhoto())
-                .jobId(content.getJob().getId())
-                .build();
-    }
+public class ContentResponseDTO {
+    private Long id;
+    private String title;
+    private String url;
+    private String photo;
+    private Long jobId;
 }

--- a/src/main/java/UMC/career_mate/domain/content/service/ContentService.java
+++ b/src/main/java/UMC/career_mate/domain/content/service/ContentService.java
@@ -1,59 +1,57 @@
 package UMC.career_mate.domain.content.service;
 
+
 import UMC.career_mate.domain.content.Content;
+import UMC.career_mate.domain.content.converter.ContentConverter;
 import UMC.career_mate.domain.content.dto.request.ContentRequestDTO;
 import UMC.career_mate.domain.content.dto.response.ContentResponseDTO;
 import UMC.career_mate.domain.content.repository.ContentRepository;
-import UMC.career_mate.domain.job.Job;
-import UMC.career_mate.domain.job.repository.JobRepository;
-import UMC.career_mate.domain.member.Member;
-import UMC.career_mate.domain.member.repository.MemberRepository;
-import UMC.career_mate.global.response.exception.GeneralException;
-import UMC.career_mate.global.response.exception.code.CommonErrorCode;
+import UMC.career_mate.domain.job.Service.JobService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ContentService {
 
     private final ContentRepository contentRepository;
-    private final JobRepository jobRepository;
-    private final MemberRepository memberRepository;
+    private final JobService jobService;
+    private final ContentConverter contentConverter;
 
-    @Transactional
     public ContentResponseDTO uploadContent(ContentRequestDTO contentRequestDTO) {
-        // Job ID로 Job 엔티티 검색
-        Job job = jobRepository.findById(contentRequestDTO.jobId())
-                .orElseThrow(() -> new GeneralException(CommonErrorCode.NOT_FOUND_JOB));
+        // Job ID 유효성 확인
+        var job = jobService.findJobById(contentRequestDTO.jobId());
 
         // Content 엔티티 생성 및 저장
-        Content content = Content.builder()
-                .title(contentRequestDTO.title())
-                .url(contentRequestDTO.url())
-                .photo(contentRequestDTO.photo())
-                .job(job)
-                .build();
-
+        Content content = contentConverter.toContent(contentRequestDTO, job);
         contentRepository.save(content);
 
-        return ContentResponseDTO.fromEntity(content);
+        return contentConverter.toContentResponseDTO(content);
     }
 
+    @Transactional(readOnly = true)
     public List<ContentResponseDTO> getContentsByJobId(Long jobId, int page, int size) {
-        PageRequest pageRequest = PageRequest.of(page - 1, size);
-        Page<Content> contents = contentRepository.findByJobId(jobId, pageRequest);
+        // Job 유효성 확인
+        jobService.findJobById(jobId);
 
-        return contents.stream()
-                .map(ContentResponseDTO::fromEntity)
+        PageRequest pageRequest = PageRequest.of(page - 1, size);
+        Page<Content> contentPage = contentRepository.findByJobId(jobId, pageRequest);
+
+        // 빈 페이지 처리
+        if (contentPage.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return contentPage.stream()
+                .map(contentConverter::toContentResponseDTO)
                 .collect(Collectors.toList());
     }
-
-
 }

--- a/src/main/java/UMC/career_mate/domain/content/service/ContentService.java
+++ b/src/main/java/UMC/career_mate/domain/content/service/ContentService.java
@@ -6,16 +6,16 @@ import UMC.career_mate.domain.content.converter.ContentConverter;
 import UMC.career_mate.domain.content.dto.request.ContentRequestDTO;
 import UMC.career_mate.domain.content.dto.response.ContentResponseDTO;
 import UMC.career_mate.domain.content.repository.ContentRepository;
+import UMC.career_mate.domain.job.Job;
 import UMC.career_mate.domain.job.Service.JobService;
+import UMC.career_mate.global.common.PageResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,34 +24,32 @@ public class ContentService {
 
     private final ContentRepository contentRepository;
     private final JobService jobService;
-    private final ContentConverter contentConverter;
 
     public ContentResponseDTO uploadContent(ContentRequestDTO contentRequestDTO) {
         // Job ID 유효성 확인
-        var job = jobService.findJobById(contentRequestDTO.jobId());
+        Job job = jobService.findJobById(contentRequestDTO.jobId());
 
         // Content 엔티티 생성 및 저장
-        Content content = contentConverter.toContent(contentRequestDTO, job);
+        Content content = ContentConverter.toContent(contentRequestDTO, job);
         contentRepository.save(content);
 
-        return contentConverter.toContentResponseDTO(content);
+        return ContentConverter.toContentResponseDTO(content);
     }
 
     @Transactional(readOnly = true)
-    public List<ContentResponseDTO> getContentsByJobId(Long jobId, int page, int size) {
+    public PageResponseDTO<List<ContentResponseDTO>> getContentsByJobId(Long jobId, int page, int size) {
         // Job 유효성 확인
         jobService.findJobById(jobId);
 
         PageRequest pageRequest = PageRequest.of(page - 1, size);
         Page<Content> contentPage = contentRepository.findByJobId(jobId, pageRequest);
 
-        // 빈 페이지 처리
-        if (contentPage.isEmpty()) {
-            return Collections.emptyList();
-        }
+        // 빈페이지를 따로 처리하지 않고 PageResponseDTO로 감싸서 반환하는 방식으로 바꾸었습니다!
+        List<ContentResponseDTO> contentList = contentPage.stream()
+                .map(ContentConverter::toContentResponseDTO)
+                .toList();
 
-        return contentPage.stream()
-                .map(contentConverter::toContentResponseDTO)
-                .collect(Collectors.toList());
+        boolean hasNext = contentPage.hasNext();
+        return new PageResponseDTO<>(page, hasNext, contentList);
     }
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

조회시 페이징 결과를 PageResponseDTO로 한번 감싸 리턴되도록 하였고, Converter를 static 메서드를 사용하는 방식으로 통일, DTO를 record로 통일해 사용하였습니다! 빈 페이지 처리 부분을 Collections.emptyList() 반환 방식에서 PageResponseDTO로 감싸는 방식으로 변경하였습니다.

작동 화면은 아래와 같습니다.

![image](https://github.com/user-attachments/assets/19675b42-9165-4e53-9532-6fbf8fb317fc)
![image](https://github.com/user-attachments/assets/b1ecb1c6-7880-46ae-a73c-44d5df159b91)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
