### PR TITLE
[CMAT-38] feat: 직무별 추천 컨텐츠 조회 api에 회원 스크랩 여부 추가

### DIFF
--- a/src/main/java/UMC/career_mate/domain/content/controller/ContentController.java
+++ b/src/main/java/UMC/career_mate/domain/content/controller/ContentController.java
@@ -47,18 +47,20 @@ public class ContentController {
     @Operation(
             summary = "직무별 컨텐츠 조회 API",
             description = """
-                    특정 직무 ID에 해당하는 컨텐츠를 조회합니다.
-                    Query Parameters:
-                    - `jobId`: 직무 ID (필수)
-                    - `page`: 페이지 번호 (기본값: 1)
-                    - `size`: 페이지 크기 (기본값: 10)
-                    """
+                특정 직무 ID에 해당하는 컨텐츠를 조회합니다.
+                이때 사용자가 해당 컨텐츠를 스크랩했는지 여부가 담겨 조회됩니다.
+                Query Parameters:
+                - `jobId`: 직무 ID (필수)
+                - `page`: 페이지 번호 (기본값: 1)
+                - `size`: 페이지 크기 (기본값: 10)
+                """
     )
     public ApiResponse<PageResponseDTO<List<ContentResponseDTO>>> getContentsByJobId(
             @RequestParam Long jobId,
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        return ApiResponse.onSuccess(contentService.getContentsByJobId(jobId, page, size));
+            @RequestParam(defaultValue = "10") int size,
+            @LoginMember Member member) {
+        return ApiResponse.onSuccess(contentService.getContentsByJobId(jobId, page, size, member));
     }
 
     @PostMapping("/{contentId}/scrap")

--- a/src/main/java/UMC/career_mate/domain/content/converter/ContentConverter.java
+++ b/src/main/java/UMC/career_mate/domain/content/converter/ContentConverter.java
@@ -25,4 +25,15 @@ public class ContentConverter {
                 .jobId(content.getJob().getId())
                 .build();
     }
+
+    public static ContentResponseDTO toContentResponseDTOWithScrapStatus(Content content, boolean isScrapped) {
+        return ContentResponseDTO.builder()
+                .id(content.getId())
+                .title(content.getTitle())
+                .url(content.getUrl())
+                .photo(content.getPhoto())
+                .jobId(content.getJob().getId())
+                .isScrapped(isScrapped)
+                .build();
+    }
 }

--- a/src/main/java/UMC/career_mate/domain/content/dto/response/ContentResponseDTO.java
+++ b/src/main/java/UMC/career_mate/domain/content/dto/response/ContentResponseDTO.java
@@ -8,6 +8,7 @@ public record ContentResponseDTO(
         String title,
         String url,
         String photo,
-        Long jobId
+        Long jobId,
+        boolean isScrapped // 추가
 ) {
 }

--- a/src/main/java/UMC/career_mate/domain/content/service/ContentService.java
+++ b/src/main/java/UMC/career_mate/domain/content/service/ContentService.java
@@ -6,8 +6,10 @@ import UMC.career_mate.domain.content.converter.ContentConverter;
 import UMC.career_mate.domain.content.dto.request.ContentRequestDTO;
 import UMC.career_mate.domain.content.dto.response.ContentResponseDTO;
 import UMC.career_mate.domain.content.repository.ContentRepository;
+import UMC.career_mate.domain.contentScrap.repository.ContentScrapRepository;
 import UMC.career_mate.domain.job.Job;
 import UMC.career_mate.domain.job.Service.JobService;
+import UMC.career_mate.domain.member.Member;
 import UMC.career_mate.global.common.PageResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,6 +26,7 @@ public class ContentService {
 
     private final ContentRepository contentRepository;
     private final JobService jobService;
+    private final ContentScrapRepository contentScrapRepository;
 
     public ContentResponseDTO uploadContent(ContentRequestDTO contentRequestDTO) {
         // Job ID 유효성 확인
@@ -37,16 +40,22 @@ public class ContentService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponseDTO<List<ContentResponseDTO>> getContentsByJobId(Long jobId, int page, int size) {
-        // Job 유효성 확인
+    public PageResponseDTO<List<ContentResponseDTO>> getContentsByJobId(Long jobId, int page, int size, Member member) {
+        // Job ID 유효성 확인
         jobService.findJobById(jobId);
 
         PageRequest pageRequest = PageRequest.of(page - 1, size);
         Page<Content> contentPage = contentRepository.findByJobId(jobId, pageRequest);
 
-        // 빈페이지를 따로 처리하지 않고 PageResponseDTO로 감싸서 반환하는 방식으로 바꾸었습니다!
+        // 사용자가 스크랩한 콘텐츠들 id 가져오기
+        List<Long> scrappedContentIds = contentScrapRepository.findByMember(member)
+                .stream()
+                .map(scrap -> scrap.getContent().getId())
+                .toList();
+
+        // 컨텐츠가 위 목록에 있는지 확인하며 isScrapped 값을 포함(true) 포함x(false) 설정
         List<ContentResponseDTO> contentList = contentPage.stream()
-                .map(ContentConverter::toContentResponseDTO)
+                .map(content -> ContentConverter.toContentResponseDTOWithScrapStatus(content, scrappedContentIds.contains(content.getId())))
                 .toList();
 
         boolean hasNext = contentPage.hasNext();

--- a/src/main/java/UMC/career_mate/domain/contentScrap/repository/ContentScrapRepository.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/repository/ContentScrapRepository.java
@@ -5,11 +5,18 @@ import UMC.career_mate.domain.member.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ContentScrapRepository extends JpaRepository<ContentScrap, Long> {
     Optional<ContentScrap> findByContentIdAndMember(Long contentId, Member member);
 
     Page<ContentScrap> findByMember(Member member, Pageable pageable);
+
+    //회원이 스크랩한 컨텐츠를 모두 조회
+    @Query("SELECT cs FROM ContentScrap cs WHERE cs.member = :member")
+    List<ContentScrap> findByMember(@Param("member") Member member);
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

## 📝 작업 내용

1. 직무별로 컨텐츠를 조회하는 기능에 로그인한 회원이 스크랩하였는지 여부 (isScrapped)를 추가하여 반환하도록 하였습니다.

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

동작 화면은 다음과 같습니다.
![image](https://github.com/user-attachments/assets/78e4a687-d232-41ca-8d5c-a443079fcd53)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

직무별로 추천 컨텐츠를 조회하는 api에 로그인한 사용자가 해당 컨텐츠를 스크랩하였는지 여부를 포함하여 반환하도록 isScrapped 항목을 추가하였습니다!
사용자가 스크랩한 컨텐츠들의 id를 contentScrapRepository 에서 가져와 이 목록에 컨텐츠가 있는지 확인해 isScrapped 값을 설정하는 방식으로 구현해두었는데, 혹시 더 개선할 수 있는 부분이 있을지 고민이 됩니다,,, 수정할 부분이나 개선점이 있다면 알려주시면 감사하겠습니다 🙇‍♀️