### PR TITLE
[CMAT-42] feat: 채용 공고 조회 시 더미 데이터 -> 사용자 답변 데이터를 사용하도록 수정

### DIFF
--- a/src/main/java/UMC/career_mate/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/UMC/career_mate/domain/answer/repository/AnswerRepository.java
@@ -1,6 +1,7 @@
 package UMC.career_mate.domain.answer.repository;
 
 import UMC.career_mate.domain.answer.Answer;
+import UMC.career_mate.domain.job.Job;
 import UMC.career_mate.domain.member.Member;
 import UMC.career_mate.domain.question.Question;
 import UMC.career_mate.domain.template.enums.TemplateType;
@@ -12,18 +13,35 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
     @Query("""
-            SELECT a FROM Answer a
+                SELECT a FROM Answer a
+                WHERE a.member = :member AND a.question.template.templateType = :templateType
+        """)
+    List<Answer> findByMemberAndTemplateType(@Param("member") Member member,
+        @Param("templateType") TemplateType templateType);
+
+    Optional<Answer> findByMemberAndQuestionAndSequence(Member member, Question question,
+        Long sequence);
+
+    @Query("""
+            SELECT COUNT(a) > 0 FROM Answer a
             WHERE a.member = :member AND a.question.template.templateType = :templateType
-    """)
-    List<Answer> findByMemberAndTemplateType(@Param("member") Member member, @Param("templateType") TemplateType templateType);
+        """)
+    boolean existsByMemberAndTemplateType(@Param("member") Member member,
+        @Param("templateType") TemplateType templateType);
 
-    Optional<Answer> findByMemberAndQuestionAndSequence(Member member, Question question, Long sequence);
+    @Query("select a from Answer a where a.member = :member and a.question.template.templateType in :templateTypes and a.question.order = :order and a.sequence = :sequence and a.question.template.job = :job")
+    List<Answer> findByMemberAndTemplateTypesAndOrderAndJob(@Param("member") Member member,
+        @Param("templateTypes") List<TemplateType> templateTypes, @Param("order") int order,
+        @Param("sequence") int sequence, @Param("job") Job job);
 
-    @Query("""
-        SELECT COUNT(a) > 0 FROM Answer a
-        WHERE a.member = :member AND a.question.template.templateType = :templateType
-    """)
-    boolean existsByMemberAndTemplateType(@Param("member") Member member, @Param("templateType") TemplateType templateType);
+    @Query("select a from Answer a where a.member = :member and a.question.content = :content and a.question.template.templateType = :templateType and a.question.template.job = :job")
+    List<Answer> findAnswersByMemberAndQuestionContentAndTemplateTypeAndJob(
+        @Param("member") Member member, @Param("content") String content,
+        @Param("templateType") TemplateType templateType, @Param("job") Job job);
 
+    @Query("select a from Answer a where a.member = :member and a.question.template.templateType in :templateTypes and a.question.template.job = :job")
+    List<Answer> findByMemberAndTemplateTypesAndJob(@Param("member") Member member,
+        @Param("templateTypes") List<TemplateType> templateTypes, @Param("job") Job job);
 }

--- a/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
+++ b/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
@@ -52,7 +52,7 @@ public class AnswerCommandService {
 
                 existingAnswer.updateContent(answerInfo.content());
 
-                // order 1 sequence 1인 질문은 수정일을 매번 업데이트 -> recruit 조회 로직에서 사용
+                // 질문 order 1의 답변 sequence 1은 수정일을 매번 업데이트 -> recruit 조회 로직에서 사용
                 if (question.getOrder() == 1 && existingAnswer.getSequence() == 1) {
                     existingAnswer.setUpdatedAt();
                 }

--- a/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
+++ b/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
@@ -52,7 +52,7 @@ public class AnswerCommandService {
 
                 existingAnswer.updateContent(answerInfo.content());
 
-                // order 1 sequence 1인 질문은 수정일을 매번 업데이트 -> recruit 조회로직에서 사용
+                // order 1 sequence 1인 질문은 수정일을 매번 업데이트 -> recruit 조회 로직에서 사용
                 if (question.getOrder() == 1 && existingAnswer.getSequence() == 1) {
                     existingAnswer.setUpdatedAt();
                 }

--- a/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
+++ b/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
@@ -51,6 +51,11 @@ public class AnswerCommandService {
                         .orElseThrow(() -> new GeneralException(CommonErrorCode.NOT_FOUND_ANSWER));
 
                 existingAnswer.updateContent(answerInfo.content());
+
+                // order 1 sequence 1인 질문은 수정일을 매번 업데이트 -> recruit 조회로직에서 사용
+                if (question.getOrder() == 1 && existingAnswer.getSequence() == 1) {
+                    existingAnswer.setUpdatedAt();
+                }
             }
         }
     }

--- a/src/main/java/UMC/career_mate/domain/chatgpt/GptAnswer.java
+++ b/src/main/java/UMC/career_mate/domain/chatgpt/GptAnswer.java
@@ -1,0 +1,52 @@
+package UMC.career_mate.domain.chatgpt;
+
+import UMC.career_mate.domain.member.Member;
+import UMC.career_mate.domain.recruit.enums.RecruitKeyword;
+import UMC.career_mate.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "gpt_answers")
+@SQLRestriction("deleted_at is NULL")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class GptAnswer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "gpt_answer_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private RecruitKeyword recruitKeyword;
+
+    private int careerYear;
+
+    public void updateData(RecruitKeyword recruitKeyword, int careerYear) {
+        this.recruitKeyword = recruitKeyword;
+        this.careerYear = careerYear;
+        super.setUpdatedAt();
+    }
+}

--- a/src/main/java/UMC/career_mate/domain/chatgpt/GptAnswer.java
+++ b/src/main/java/UMC/career_mate/domain/chatgpt/GptAnswer.java
@@ -12,7 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -35,7 +35,7 @@ public class GptAnswer extends BaseEntity {
     @Column(name = "gpt_answer_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/UMC/career_mate/domain/chatgpt/converter/GptAnswerConverter.java
+++ b/src/main/java/UMC/career_mate/domain/chatgpt/converter/GptAnswerConverter.java
@@ -1,0 +1,16 @@
+package UMC.career_mate.domain.chatgpt.converter;
+
+import UMC.career_mate.domain.chatgpt.GptAnswer;
+import UMC.career_mate.domain.member.Member;
+import UMC.career_mate.domain.recruit.enums.RecruitKeyword;
+
+public class GptAnswerConverter {
+
+    public static GptAnswer toEntity(Member member, RecruitKeyword recruitKeyword, int careerYear) {
+        return GptAnswer.builder()
+            .member(member)
+            .recruitKeyword(recruitKeyword)
+            .careerYear(careerYear)
+            .build();
+    }
+}

--- a/src/main/java/UMC/career_mate/domain/chatgpt/repository/GptAnswerRepository.java
+++ b/src/main/java/UMC/career_mate/domain/chatgpt/repository/GptAnswerRepository.java
@@ -1,0 +1,11 @@
+package UMC.career_mate.domain.chatgpt.repository;
+
+import UMC.career_mate.domain.chatgpt.GptAnswer;
+import UMC.career_mate.domain.member.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GptAnswerRepository extends JpaRepository<GptAnswer, Long> {
+
+    Optional<GptAnswer> findByMember(Member member);
+}

--- a/src/main/java/UMC/career_mate/domain/chatgpt/service/ChatGptService.java
+++ b/src/main/java/UMC/career_mate/domain/chatgpt/service/ChatGptService.java
@@ -2,12 +2,10 @@ package UMC.career_mate.domain.chatgpt.service;
 
 import UMC.career_mate.domain.chatgpt.dto.api.response.ChatCompletionResponse;
 import UMC.career_mate.domain.chatgpt.dto.request.ChatGPTRequestDTO;
-import UMC.career_mate.domain.chatgpt.dto.response.FilterConditionDTO;
 import UMC.career_mate.domain.chatgpt.dto.api.request.GptRequest;
 import UMC.career_mate.domain.chatgpt.dto.api.request.GptRequest.Message;
 import UMC.career_mate.domain.recruit.enums.RecruitKeyword;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.util.Collections;
@@ -32,29 +30,48 @@ public class ChatGptService {
     @Value("${chat-gpt.service-key}")
     private String serviceKey;
 
-    private static final String GPT_REQUEST_FORMAT_PREFIX_FOR_CAREER_YEAR =
-        "다음 이력서 데이터를 기반으로 추천 직무와 총 경력을 계산해줘. " +
-        "직무는 'BACKEND_SPRING', 'BACKEND_NODE', 'BACKEND_DJANGO', 'FRONTEND', 'DESIGNER', 'PM' 중 하나로 선택하고, " +
-        "총 경력은 각 회사의 근무 기간을 더해서 소수 말고 정수로만 결과를 계산해줘. " +
-        "응답은 JSON으로 {\"직무\": \"추천 직무\", \"경력\": \"총 경력(년차)\"} 형식으로 작성해줘.";
+    private static final String GPT_REQUEST_FORMAT_POSTFIX_FOR_CAREER_YEAR =
+        "이 사람의 경력을 계산해서 앞뒤 설명 하지말고 정수로만 올바른 답변 예시와 같은 형식으로 답변해줘. " +
+            "올바론 답변 예시) 5, 잘못된 답변 예시 1) 5년, 잘못된 답변 예시 2) 5 years, 잘못된 답변 예시 3) 이 사람의 경력은 5년";
+
+    private static final String GPT_REQUEST_FORMAT_POSTFIX_FOR_RECRUIT_KEYWORD =
+        "이 사람의 직무를 내가 제시한 보기들 중에서 하나만 골라서 답변해줘.\n" +
+            "직무 보기 :'BACKEND', 'BACKEND_SPRING', 'BACKEND_NODE', 'BACKEND_DJANGO', 'FRONTEND', 'DESIGNER', 'PM', "
+            +
+            "이 중에서 적절한 직무가 없다면 'MISMATCH'로 답변해줘.\n" +
+            "앞뒤 설명하지 말고 직무만 답변해줘.";
 
     private static final String GPT_REQUEST_FORMAT_PREFIX_FOR_COMMENT =
         " = 사용자 이름이고, 다음 이력서 데이터를 기반으로 사용자의 강점을 어필할 수 있고, " +
-        "어떤 포지션이 어울리는지 어떤 경험을 어필하면 좋을지 그런 내용들로 추천 조언 문구를 생성해줘. " +
-        "'~~한 경험이 있는 000님, ~~한 경험을 어필해보면 어때요?', 또는 '~~포지에 지원해보 건 어떨까요? ~~에 강점을 드러낼 수 있을 것 같아요.'" +
-        "와 비슷한 형식이지만 꼭 이런 형식이 아니더라도 너만의 스타일로 문구를 생성해줘." +
-        "말투는 \"입니다\"같은 딱딱말 말투는 사용하지 말고, \"요.\"같이 부드럽게 표현해줘. " +
-        "답변은 문구만 답변해줘. 문구를 생성할 때 이력서 데이터의 회사 이름은 제외해줘. 답변에서 엔터나 - 같은건 빼줘.";
+            "어떤 포지션이 어울리는지 어떤 경험을 어필하면 좋을지 그런 내용들로 추천 조언 문구를 생성해줘. " +
+            "'~~한 경험이 있는 000님, ~~한 경험을 어필해보면 어때요?', 또는 '~~포지에 지원해보 건 어떨까요? ~~에 강점을 드러낼 수 있을 것 같아요.'"
+            +
+            "와 비슷한 형식이지만 꼭 이런 형식이 아니더라도 너만의 스타일로 문구를 생성해줘." +
+            "말투는 \"입니다\"같은 딱딱말 말투는 사용하지 말고, \"요.\"같이 부드럽게 표현해줘. " +
+            "답변은 문구만 답변해줘. 문구를 생성할 때 이력서 데이터의 회사 이름은 제외해줘. 답변에서 엔터나 - 같은건 빼줘.";
 
-    public FilterConditionDTO getFilterCondition(ChatGPTRequestDTO chatGPTRequestDTO) {
+    public int getCareerYear(String chatGptRequestContent) {
         GptRequest gptRequest = createGptRequest(
-            GPT_REQUEST_FORMAT_PREFIX_FOR_CAREER_YEAR + " " + chatGPTRequestDTO.content());
+            chatGptRequestContent + GPT_REQUEST_FORMAT_POSTFIX_FOR_CAREER_YEAR);
 
         ObjectMapper om = new ObjectMapper();
         String gptAnswer = getGptAnswer(om, gptRequest);
 
-        // "직무"와 "경력" 추출
-        return extractJobAndCareer(om, gptAnswer);
+        log.info("\ngptRequest : {}, gptAnswer : {} ", gptRequest, gptAnswer);
+
+        return Integer.parseInt(gptAnswer);
+    }
+
+    public RecruitKeyword getRecruitKeyword(String chatGptRequestContent) {
+        GptRequest gptRequest = createGptRequest(
+            chatGptRequestContent + GPT_REQUEST_FORMAT_POSTFIX_FOR_RECRUIT_KEYWORD);
+
+        ObjectMapper om = new ObjectMapper();
+        String gptAnswer = getGptAnswer(om, gptRequest);
+
+        log.info("\ngptRequest : {}, gptAnswer : {} ", gptRequest, gptAnswer);
+
+        return RecruitKeyword.getRecruitKeywordFromGptAnswerJob(gptAnswer);
     }
 
     public String getComment(ChatGPTRequestDTO chatGPTRequestDTO) {
@@ -152,29 +169,5 @@ public class ChatGptService {
 
     private String parseGptResponse(ChatCompletionResponse response) {
         return response.choices().get(0).message().content();
-    }
-
-    private FilterConditionDTO extractJobAndCareer(ObjectMapper om, String gptAnswer) {
-        JsonNode rootNode = null;
-        try {
-            rootNode = om.readTree(gptAnswer);
-        } catch (JsonProcessingException e) {
-            log.error("직무 경력 gpt 답변 결과 파싱 중 에러");
-            throw new RuntimeException(e);
-        }
-
-        String job = rootNode.get("직무").asText();
-        String career = rootNode.get("경력").asText();
-        int careerYear = Integer.parseInt(career.split("년")[0]);
-
-        log.info("추천 직무: {}", job);
-        log.info("추천 경력: {}", career);
-
-        RecruitKeyword recruitKeyword = RecruitKeyword.getRecruitKeyword(job);
-
-        return FilterConditionDTO.builder()
-            .recruitKeyword(recruitKeyword)
-            .careerYear(careerYear)
-            .build();
     }
 }

--- a/src/main/java/UMC/career_mate/domain/chatgpt/service/GptAnswerCommandService.java
+++ b/src/main/java/UMC/career_mate/domain/chatgpt/service/GptAnswerCommandService.java
@@ -1,0 +1,29 @@
+package UMC.career_mate.domain.chatgpt.service;
+
+import UMC.career_mate.domain.chatgpt.GptAnswer;
+import UMC.career_mate.domain.chatgpt.converter.GptAnswerConverter;
+import UMC.career_mate.domain.chatgpt.repository.GptAnswerRepository;
+import UMC.career_mate.domain.member.Member;
+import UMC.career_mate.domain.recruit.enums.RecruitKeyword;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public class GptAnswerCommandService {
+
+    private final GptAnswerRepository gptAnswerRepository;
+
+    public void saveGptAnswer(Member member, RecruitKeyword recruitKeyword, int careerYear) {
+        GptAnswer gptAnswer = GptAnswerConverter.toEntity(member, recruitKeyword, careerYear);
+        gptAnswerRepository.save(gptAnswer);
+    }
+
+    public void updateGptAnswer(GptAnswer gptAnswer, RecruitKeyword recruitKeyword, int careerYear) {
+        gptAnswer.updateData(recruitKeyword, careerYear);
+        gptAnswerRepository.save(gptAnswer);
+    }
+}

--- a/src/main/java/UMC/career_mate/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/controller/RecruitController.java
@@ -46,7 +46,7 @@ public class RecruitController {
         @RequestParam(defaultValue = "6", required = false) int size,
         @RequestParam(defaultValue = "POSTING_DESC", required = false) RecruitSortType recruitSortType,
         @LoginMember Member member
-        ) {
+    ) {
         return ApiResponse.onSuccess(
             recruitQueryService.getRecommendRecruitList(page, size, recruitSortType, member));
     }
@@ -54,11 +54,12 @@ public class RecruitController {
     @Operation(
         summary = "채용 공고 요약 페이지 조회 API",
         description = """
-        채용 공고 요약 페이지를 조회하는 API입니다.\n\n
-        recruitId : 조회하려는 채용 공고 pk 값
-        """)
+            채용 공고 요약 페이지를 조회하는 API입니다.\n\n
+            recruitId : 조회하려는 채용 공고 pk 값
+            """)
     @GetMapping("/{recruitId}")
-    public ResponseEntity<ApiResponse<RecruitInfoDTO>> getRecruitInfo(@PathVariable Long recruitId, @LoginMember Member member) {
+    public ResponseEntity<ApiResponse<RecruitInfoDTO>> getRecruitInfo(@PathVariable Long recruitId,
+        @LoginMember Member member) {
         return ResponseEntity.ok(
             ApiResponse.onSuccess(recruitQueryService.findRecruitInfo(member, recruitId)));
     }

--- a/src/main/java/UMC/career_mate/domain/recruit/converter/RecruitConverter.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/converter/RecruitConverter.java
@@ -1,10 +1,12 @@
 package UMC.career_mate.domain.recruit.converter;
 
 import UMC.career_mate.domain.recruit.Recruit;
+import UMC.career_mate.domain.recruit.dto.FilterConditionDTO;
 import UMC.career_mate.domain.recruit.dto.api.SaraminResponseDTO.Job;
 import UMC.career_mate.domain.recruit.dto.response.RecommendRecruitDTO;
 import UMC.career_mate.domain.recruit.dto.response.RecruitInfoDTO;
 import UMC.career_mate.domain.recruit.enums.EducationLevel;
+import UMC.career_mate.domain.recruit.enums.RecruitKeyword;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -75,6 +77,13 @@ public class RecruitConverter {
             .region(recruit.getRegion())
             .companyInfoUrl(recruit.getCompanyInfoUrl())
             .recruitUrl(recruit.getRecruitUrl())
+            .build();
+    }
+
+    public static FilterConditionDTO toFilterConditionDTO(RecruitKeyword recruitKeyword, int careerYear) {
+        return FilterConditionDTO.builder()
+            .recruitKeyword(recruitKeyword)
+            .careerYear(careerYear)
             .build();
     }
 

--- a/src/main/java/UMC/career_mate/domain/recruit/dto/FilterConditionDTO.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/dto/FilterConditionDTO.java
@@ -1,4 +1,4 @@
-package UMC.career_mate.domain.chatgpt.dto.response;
+package UMC.career_mate.domain.recruit.dto;
 
 import UMC.career_mate.domain.recruit.enums.RecruitKeyword;
 import lombok.Builder;

--- a/src/main/java/UMC/career_mate/domain/recruit/enums/RecruitKeyword.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/enums/RecruitKeyword.java
@@ -1,9 +1,22 @@
 package UMC.career_mate.domain.recruit.enums;
 
+import UMC.career_mate.domain.job.Job;
 import java.util.List;
 
 public enum RecruitKeyword {
 
+    BACKEND {
+        @Override
+        public List<String> getIncludeKeywordList() {
+            return List.of("Back", "Backend", "Back-end", "BACK", "백엔드", "서버", "시스템");
+        }
+
+        @Override
+        public List<String> getExcludeKeywordList() {
+            return null;
+        }
+    }
+    ,
     BACKEND_SPRING {
         @Override
         public List<String> getIncludeKeywordList() {
@@ -75,13 +88,23 @@ public enum RecruitKeyword {
 
     ;
 
-    public static RecruitKeyword getRecruitKeyword(String name) {
+    public static RecruitKeyword getRecruitKeywordFromGptAnswerJob(String name) {
         for (RecruitKeyword recruitKeyword : RecruitKeyword.values()) {
             if (recruitKeyword.toString().equals(name)) {
                 return recruitKeyword;
             }
         }
-        return null; // 일치하는거 없으면 일단 Null 반환 처리
+        return null; // 일치하는거 없으면 null
+    }
+
+    public static RecruitKeyword getRecruitKeywordFromProfileJob(Job job) {
+        return switch (job.getName()) {
+            case "백엔드 개발자" -> BACKEND;
+            case "프론트엔드 개발자" -> FRONTEND;
+            case "PM(Product/Project Manager)" -> PM;
+            case "Designer" -> DESIGNER;
+            default -> throw new RuntimeException("추가 필요한 직무" + job.getName());
+        };
     }
 
 

--- a/src/main/java/UMC/career_mate/domain/recruit/service/RecruitQueryService.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/service/RecruitQueryService.java
@@ -1,22 +1,35 @@
 package UMC.career_mate.domain.recruit.service;
 
+import UMC.career_mate.domain.answer.Answer;
+import UMC.career_mate.domain.answer.repository.AnswerRepository;
+import UMC.career_mate.domain.chatgpt.GptAnswer;
 import UMC.career_mate.domain.chatgpt.dto.request.ChatGPTRequestDTO;
-import UMC.career_mate.domain.chatgpt.dto.response.FilterConditionDTO;
+import UMC.career_mate.domain.chatgpt.service.GptAnswerCommandService;
+import UMC.career_mate.domain.recruit.dto.FilterConditionDTO;
+import UMC.career_mate.domain.chatgpt.repository.GptAnswerRepository;
 import UMC.career_mate.domain.chatgpt.service.ChatGptService;
+import UMC.career_mate.domain.job.Job;
 import UMC.career_mate.domain.member.Member;
 import UMC.career_mate.domain.recruit.Recruit;
 import UMC.career_mate.domain.recruit.converter.RecruitConverter;
 import UMC.career_mate.domain.recruit.dto.response.RecommendRecruitDTO;
 import UMC.career_mate.domain.recruit.dto.response.RecruitInfoDTO;
 import UMC.career_mate.domain.recruit.enums.EducationLevel;
+import UMC.career_mate.domain.recruit.enums.RecruitKeyword;
 import UMC.career_mate.domain.recruit.enums.RecruitSortType;
 import UMC.career_mate.domain.recruit.repository.RecruitRepository;
 import UMC.career_mate.domain.recruitScrap.repository.RecruitScrapRepository;
+import UMC.career_mate.domain.template.enums.TemplateType;
 import UMC.career_mate.global.common.PageResponseDTO;
 import UMC.career_mate.global.response.exception.GeneralException;
 import UMC.career_mate.global.response.exception.code.CommonErrorCode;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -24,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -33,15 +47,32 @@ public class RecruitQueryService {
     private final ChatGptService chatGptService;
     private final RecruitScrapRepository recruitScrapRepository;
 
+    private final AnswerRepository answerRepository;
+
+    private final GptAnswerRepository gptAnswerRepository;
+    private final GptAnswerCommandService gptAnswerCommandService;
+
+    private final static int ONLY_ENTER_LENGTH = 2;
+    private final static int NO_INTERN_EXPERIENCE = 0;
+    private final static String PROJECT_PREFIX = "프로젝트 경험 데이터 : ";
+    private final static String INTERN_PREFIX = "인턴 경험 데이터 : ";
+    private final static String PROJECT_QUESTION_CONTENT_PERIOD = "기간";
+    private final static String INTERN_QUESTION_CONTENT_PERIOD = "근무기간";
+
     public PageResponseDTO<List<RecommendRecruitDTO>> getRecommendRecruitList(int page, int size,
         RecruitSortType recruitSortType, Member member) {
+        // GptAnswer 엔티티를 조회한다.
+        Optional<GptAnswer> findGptAnswer = gptAnswerRepository.findByMember(member);
 
-        // TODO: db에서 사용자의 템플릿 데이터 가져오는걸로 수정
-        // TODO: 템플릿 수정일과 gpt 요청일 비교 후 수정일이 더 최근인 경우 gpt에 템플릿 분석 요청, 아니면 저장해둔 경력 데이터 재사용 로직 추가
-        ChatGPTRequestDTO chatGPTRequestDTO = createDummyData(member);
+        // 인턴 템플릿 답변 데이터와 프로젝트 템플릿 답변 데이터의 질문의 order, sequence 1번을 조회해서 마지막 수정일을 확인한다. -> 최대 2개 조회.
+        List<Answer> internAndProjectAnswersFromFirstQuestion = answerRepository.findByMemberAndTemplateTypesAndOrderAndJob(
+            member, List.of(TemplateType.INTERN_EXPERIENCE, TemplateType.PROJECT_EXPERIENCE), 1, 1,
+            member.getJob());
 
-        FilterConditionDTO filterCondition = chatGptService.getFilterCondition(chatGPTRequestDTO);
+        FilterConditionDTO filterCondition = createFilterCondition(member, findGptAnswer,
+            internAndProjectAnswersFromFirstQuestion);
 
+        // 사용자 프로필의 학력과 상태로 검색에서 사용할 EducationLevel로 치환한다.
         EducationLevel educationLevel = EducationLevel.getEducationLevelFromMemberInfo(
             member.getEducationLevel(), member.getEducationStatus());
 
@@ -64,6 +95,151 @@ public class RecruitQueryService {
         String comment = chatGptService.getComment(chatGPTRequestDTO);
 
         return RecruitConverter.toRecruitInfoDTO(comment, recruit);
+    }
+
+    private FilterConditionDTO createFilterCondition(Member member,
+        Optional<GptAnswer> findGptAnswer,
+        List<Answer> internAndProjectAnswersFromFirstQuestion) {
+
+        int careerYear;
+        RecruitKeyword recruitKeyword;
+        if (findGptAnswer.isEmpty()) { // GptAnswer이 없는 경우 (Gpt 요청 한번도 안한 경우)
+            log.info("GptAnswer가 없는 유저인 상황, GptAnswer의 insert가 발생한다");
+
+            // 인턴 템플릿 근무기간 답변 데이터에 한해서 경력을 계산한다.
+            careerYear = calculateCareerYear(member);
+
+            // 인턴 + 프로젝트 템플릿 답변 데이터에서 기간을 제외한 데이터로 추천 직무를 가져온다.
+            recruitKeyword = calculateRecruitKeyword(member);
+
+            gptAnswerCommandService.saveGptAnswer(member, recruitKeyword, careerYear);
+        } else {
+            GptAnswer gptAnswer = findGptAnswer.get();
+
+            log.info("internAndProjectAnswersFromFirstQuestion의 크기 : {}", internAndProjectAnswersFromFirstQuestion.size());
+
+            List<Answer> updatedAnswerList = internAndProjectAnswersFromFirstQuestion.stream()
+                .filter(answer -> answer.getUpdatedAt().isAfter(gptAnswer.getUpdatedAt()))
+                .toList();
+
+            // GptAnswer 마지막 요청 이후에 프로젝트 or 인턴 템플릿 답변이 수정된 경우
+            if (!updatedAnswerList.isEmpty()) {
+                log.info("마지막 Gpt 요청 이후 인턴 or 프로젝트 답변 수정한 상황, GptAnswer의 업데이트가 발생한다.");
+
+                // 인턴 템플릿 근무기간 답변 데이터에 한해서 경력을 계산한다.
+                careerYear = calculateCareerYear(member);
+
+                // 인턴 + 프로젝트 템플릿 답변 데이터에서 기간을 제외한 데이터로 추천 직무를 가져온다.
+                recruitKeyword = calculateRecruitKeyword(member);
+
+                gptAnswerCommandService.updateGptAnswer(gptAnswer, recruitKeyword, careerYear);
+            } else {
+                log.info("마지막 Gpt 요청 이후 인턴 or 프로젝트 답변 수정한 적이 없는 상황, GptAnswer에 대해 아무 일도 일어나지 않는다.");
+                careerYear = gptAnswer.getCareerYear();
+                recruitKeyword = gptAnswer.getRecruitKeyword();
+            }
+        }
+
+        return RecruitConverter.toFilterConditionDTO(recruitKeyword, careerYear);
+    }
+
+    private int calculateCareerYear(Member member) {
+        Job job = member.getJob();
+
+        // 인턴 템플릿의 근무기간 답변 데이터를 가져온다. 0개 or 2개
+        List<Answer> periodAnswerList = answerRepository.findAnswersByMemberAndQuestionContentAndTemplateTypeAndJob(
+            member, INTERN_QUESTION_CONTENT_PERIOD, TemplateType.INTERN_EXPERIENCE, job);
+
+        // 아직 답변을 안한 상태 (템플릿 답변 작성 없이 바로 공고 조회를 한 경우) -> 경력 0년 반환
+        if (periodAnswerList.isEmpty()) {
+            return NO_INTERN_EXPERIENCE;
+        }
+
+        StringBuilder contentBuilder = new StringBuilder();
+
+        periodAnswerList.forEach(
+            answer -> contentBuilder.append(answer.getContent() + "\n")
+        );
+
+        // 인턴 근무 기간이 빈 문자열인 경우 -> 경력 0년 반환
+        if (contentBuilder.length() == ONLY_ENTER_LENGTH) {
+            log.info("인턴 근무 기간이 빈 문자열인 경우 -> 경력 0년 반환");
+            return NO_INTERN_EXPERIENCE;
+        }
+
+        // 근무 기간이 입력되어 있는 경우 -> gpt에게 경력 계산 요청
+        return chatGptService.getCareerYear(contentBuilder.toString());
+    }
+
+    private RecruitKeyword calculateRecruitKeyword(Member member) {
+        Job job = member.getJob();
+
+        // 프로젝트 템플릿의 답변, 인턴 템플릿의 답변을 가져온다.
+        Map<TemplateType, List<Answer>> templateTypeByAnswers = getTemplateTypeByAnswers(
+            member, job);
+
+        List<Answer> projectAnswers = templateTypeByAnswers.getOrDefault(
+            TemplateType.PROJECT_EXPERIENCE, List.of());
+        List<Answer> internAnswers = templateTypeByAnswers.getOrDefault(
+            TemplateType.INTERN_EXPERIENCE, List.of());
+
+        // (프로젝트, 인턴) 템플릿 답변 없이, 바로 채용 공고 조회하는 경우 -> answer 생성 안된 경우
+        if (projectAnswers.isEmpty() && internAnswers.isEmpty()) {
+            return RecruitKeyword.getRecruitKeywordFromProfileJob(job);
+        }
+
+        StringBuilder contentBuilder = new StringBuilder();
+        int projectEnterCnt = createChatGptRequestContent(contentBuilder, projectAnswers,
+            PROJECT_PREFIX, PROJECT_QUESTION_CONTENT_PERIOD);
+        int internEnterCnt = createChatGptRequestContent(contentBuilder, internAnswers,
+            INTERN_PREFIX, INTERN_QUESTION_CONTENT_PERIOD);
+
+        // 최종 데이터가 기본 틀을 제외한 빈 문자열인 경우
+        if (isEmptyContentBuilder(contentBuilder, projectEnterCnt, internEnterCnt)) {
+            log.info("최종 데이터가 기본 틀 데이터를 제외하고 빈 문자열인 경우");
+            return RecruitKeyword.getRecruitKeywordFromProfileJob(job);
+        }
+
+        RecruitKeyword recruitKeyword = chatGptService.getRecruitKeyword(contentBuilder.toString());
+
+        // chatgpt 응답이 똑바로 오지 않은 경우, 기존 프로필 job으로 대체
+        if (Objects.isNull(recruitKeyword)) {
+            log.info("gpt 답변이 RecruitKeyword에 없는 값이라서 null인 경우");
+            return RecruitKeyword.getRecruitKeywordFromProfileJob(job);
+        }
+
+        return recruitKeyword;
+    }
+
+    private Map<TemplateType, List<Answer>> getTemplateTypeByAnswers(Member member, Job job) {
+        List<Answer> findAnswers = answerRepository.findByMemberAndTemplateTypesAndJob(member,
+            List.of(TemplateType.PROJECT_EXPERIENCE, TemplateType.INTERN_EXPERIENCE), job);
+
+        return findAnswers.stream()
+            .collect(Collectors.groupingBy(
+                answer -> answer.getQuestion().getTemplate().getTemplateType()));
+    }
+
+    // 답변 리스트를 StringBuilder에 추가하고, 추가된 개수를 반환
+    private int createChatGptRequestContent(StringBuilder contentBuilder, List<Answer> answers,
+        String prefix,
+        String excludeContent) {
+        contentBuilder.append(prefix);
+        int enterCnt = 0;
+        for (Answer answer : answers) {
+            if (!answer.getQuestion().getContent().equals(excludeContent)) {
+                contentBuilder.append(answer.getContent().trim()).append("\n");
+                enterCnt++;
+            }
+        }
+        return enterCnt;
+    }
+
+    // StringBuilder가 기본 틀 외에 내용이 없는지 확인
+    private boolean isEmptyContentBuilder(StringBuilder contentBuilder, int projectEnterCnt,
+        int internEnterCnt) {
+        return contentBuilder.length()
+            == PROJECT_PREFIX.length() + projectEnterCnt + INTERN_PREFIX.length() + internEnterCnt;
     }
 
     private PageResponseDTO<List<RecommendRecruitDTO>> createPageResponseDTO(int page,

--- a/src/main/java/UMC/career_mate/global/entity/BaseEntity.java
+++ b/src/main/java/UMC/career_mate/global/entity/BaseEntity.java
@@ -31,4 +31,8 @@ public abstract class BaseEntity {
     public void delete() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void setUpdatedAt() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

1. 채용 공고 조회에서 더미 데이터를 사용하던 부분을 Answer 데이터를 사용하도록 수정했습니다.
2. 매 요청마다 gpt 요청이 가지 않도록 하기 위해서 GptAnswer 엔티티를 추가했습니다.
3. 답변 마지막 updated_at을 항상 갱신시키기 위해 AnswerCommandService의 updateAnswerList 메서드에 코드 몇줄 추가했습니다.

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인
1. GptAnswer이 이미 있고, 답변 데이터 수정이 이루어지지 않은 경우 채용 공고 조회 시
<img width="450" alt="image" src="https://github.com/user-attachments/assets/cb3ca606-ad37-4ddc-be76-d2a170fd2342" />

![image](https://github.com/user-attachments/assets/84d25fec-f24b-4116-9aa1-14ca6238afaa)

---

2. 답변 수정 후 다시 채용 공고 조회 시

일단 답변 수정을 하겠습니다
<img width="350" alt="image" src="https://github.com/user-attachments/assets/2b01c02a-9962-45a8-a222-097582a4b314" />

젤 위 튜플의 updated_at만 갱신되는걸 확인할 수 있습니다 -> order 1번이면서 sequence 1번
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/6d5726c4-3ed5-4386-8320-45fe2852431c" />

![image](https://github.com/user-attachments/assets/44cdda07-9e4b-45d2-8dcc-404818299217)

기존 GptAnswer의 updated_at도 확인하겠습니다
![image](https://github.com/user-attachments/assets/f554b2f3-5697-40ec-a097-bfd023305194)

이 상태에서 조회를 하면, gpt 요청 로직이 동작해서 이전보다 조회 시간이 오래걸립니다
<img width="340" alt="image" src="https://github.com/user-attachments/assets/58e59523-5da1-4a4f-b2fa-1c941dfcfdb8" />
로그를 보면 if문도 잘 탄 것 같습니다
![image](https://github.com/user-attachments/assets/7b1389d8-20b3-4515-b708-4d292ae5a339)
GptAnswer도 새로 갱신되었습니다
![image](https://github.com/user-attachments/assets/fa5084fd-5ddb-4dab-b339-60d89c75077c)

---

3. 이렇게 한 상황에서 다시 한번 채용 공고 조회

이제 GptAnswer의 updated_at이 답변 updated_at 이후이기 때문에 gpt 요청을 하지 않습니다. (조회 시간도 짧아짐)
<img width="350" alt="image" src="https://github.com/user-attachments/assets/c2c1ea87-1bd0-4259-b580-98ca793be6bd" />
로그로 if문이 잘 타는걸 확인할 수 있습니다.
![image](https://github.com/user-attachments/assets/58cd2020-aa4a-4722-8b5c-7e94aed0d1d0)

---

4. 사용자가 템플릿에 답변을 하지 않고(답변 데이터가 db에 없음) 바로 채용 공고 조회를 할 경우

일단 Answer 테이블을 밀었습니다 (추가로 GptAnswer 테이블도 밀었습니다)
![image](https://github.com/user-attachments/assets/2e1abc8f-066d-4717-a2cc-212e86b7b5a4)

gpt에게 분석시킬 데이터가 없기 때문에 경력은 0년 처리, 직무는 member의 job으로 처리했습니다 (gpt 요청 x)
<img width="450" alt="image" src="https://github.com/user-attachments/assets/1cf61ba2-85a8-46d6-a35e-e3183eaca8af" />

경력은 0년 처리하는 부분인데, 로그를 안찍어둬서 코드로 대체하겠습니다
<img width="450" alt="image" src="https://github.com/user-attachments/assets/ba6b9cde-c9f1-4221-b310-1a3f08f62bfb" />

이 경우에도 경력은 0년 처리, 직무는 member의 job으로 처리한 데이터로 GptAnswer를 생성해서 저장합니다
![image](https://github.com/user-attachments/assets/0d872810-6051-4f7f-9297-16ee68817633)
![image](https://github.com/user-attachments/assets/0d58f9d9-ea5c-4bd4-baec-2a784eea198a)

---

5. 4번 상태에 이어서 템플릿에 대한 답변을 생성할건데 답변 content를 전부 빈 문자열로저장하겠습니다
![image](https://github.com/user-attachments/assets/783c54aa-7d9c-4593-8f35-10597710990f)

스웨거로 요청하는 캡처 사진 까먹음..

근무기간에 데이터가 빈 문자열이라서 0년 처리합니다
![image](https://github.com/user-attachments/assets/6d2db49a-325b-4aeb-96e8-a379b21f97a7)

모든 답변이 빈문자열인 경우의 if문에 걸린 로그이고, 이 경우 또한 gpt에게 요청보내지 않고 멤버 프로필의 job으로 직무에 대해 처리합니다
![image](https://github.com/user-attachments/assets/0af9a178-b296-4fe1-98c2-a325e767e9b3)

---

6. 5번에 이어 인턴 템플릿에 대해 정상적인 답변 데이터를 넣고 조회

정상 답변에 대한 db
![image](https://github.com/user-attachments/assets/0fd952b7-ae15-4305-89cc-12cfd0508967)

gpt 요청이 발생한 조회
<img width="586" alt="image" src="https://github.com/user-attachments/assets/51fb9462-010f-4caa-8da7-4ba3d35cf60e" />

로그도 if문에 잘 걸리는 걸 확인
![image](https://github.com/user-attachments/assets/fb0d4fb0-a60b-4548-a665-f95602308b4d)

GptAnswer updated_at 시간 갱신 확인 (멤버 프로필 job이랑 정상 데이터 전부 백엔드로 진행해서 직무 데이터가 다릅니다)
![image](https://github.com/user-attachments/assets/0d2af5d2-c643-44ed-b316-61d16a96181d)

---

7. 마지막으로 6번에 이어 다시 채용 공고를 조회

gpt 요청 로직 없이 조회되었습니다
<img width="450" alt="image" src="https://github.com/user-attachments/assets/ea7e22da-e7aa-492e-aeb3-10081b6d60cd" />

로그도 확인
![image](https://github.com/user-attachments/assets/d71d8c8a-eb20-426c-8967-3b10c9a179ad)

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
