### PR TITLE
[CMAT-44] fix: 템플릿 타입에 맞는 커리어 조회 API 수정

### DIFF
--- a/src/main/java/UMC/career_mate/domain/answer/controller/AnswerController.java
+++ b/src/main/java/UMC/career_mate/domain/answer/controller/AnswerController.java
@@ -128,9 +128,9 @@ public class AnswerController {
                             4. 보유 기술 (TECHNICAL_SKILLS)\s
                             5. 최종 정리 (SUMMARY)
                             """)
-    public ApiResponse<List<AnswerInfoListDTO>> getAnswerList(@RequestParam Long memberId,
+    public ApiResponse<List<AnswerInfoListDTO>> getAnswerList(@LoginMember Member member,
                                                               @RequestParam("templateType") TemplateType templateType) {
-        return ApiResponse.onSuccess(GET_ANSWER_LIST, answerQueryService.getAnswersByTemplateType(memberId, templateType));
+        return ApiResponse.onSuccess(GET_ANSWER_LIST, answerQueryService.getAnswersByTemplateType(member, templateType));
     }
 
     @PatchMapping

--- a/src/main/java/UMC/career_mate/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/UMC/career_mate/domain/answer/repository/AnswerRepository.java
@@ -15,33 +15,38 @@ import java.util.Optional;
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     @Query("""
-                SELECT a FROM Answer a
-                WHERE a.member = :member AND a.question.template.templateType = :templateType
-        """)
+                    SELECT a FROM Answer a
+                    WHERE a.member = :member
+                    AND a.question.template.job = :job
+                    AND a.question.template.templateType = :templateType
+            """)
     List<Answer> findByMemberAndTemplateType(@Param("member") Member member,
-        @Param("templateType") TemplateType templateType);
+                                             @Param("job") Job job,
+                                             @Param("templateType") TemplateType templateType);
 
-    Optional<Answer> findByMemberAndQuestionAndSequence(Member member, Question question,
-        Long sequence);
+    Optional<Answer> findByMemberAndQuestionAndSequence(Member member, Question question, Long sequence);
 
     @Query("""
-            SELECT COUNT(a) > 0 FROM Answer a
-            WHERE a.member = :member AND a.question.template.templateType = :templateType
-        """)
+                SELECT COUNT(a) > 0 FROM Answer a
+                WHERE a.member = :member
+                AND a.question.template.job = :job
+                AND a.question.template.templateType = :templateType
+            """)
     boolean existsByMemberAndTemplateType(@Param("member") Member member,
-        @Param("templateType") TemplateType templateType);
+                                          @Param("job") Job job,
+                                          @Param("templateType") TemplateType templateType);
 
     @Query("select a from Answer a where a.member = :member and a.question.template.templateType in :templateTypes and a.question.order = :order and a.sequence = :sequence and a.question.template.job = :job")
     List<Answer> findByMemberAndTemplateTypesAndOrderAndJob(@Param("member") Member member,
-        @Param("templateTypes") List<TemplateType> templateTypes, @Param("order") int order,
-        @Param("sequence") int sequence, @Param("job") Job job);
+                                                            @Param("templateTypes") List<TemplateType> templateTypes, @Param("order") int order,
+                                                            @Param("sequence") int sequence, @Param("job") Job job);
 
     @Query("select a from Answer a where a.member = :member and a.question.content = :content and a.question.template.templateType = :templateType and a.question.template.job = :job")
     List<Answer> findAnswersByMemberAndQuestionContentAndTemplateTypeAndJob(
-        @Param("member") Member member, @Param("content") String content,
-        @Param("templateType") TemplateType templateType, @Param("job") Job job);
+            @Param("member") Member member, @Param("content") String content,
+            @Param("templateType") TemplateType templateType, @Param("job") Job job);
 
     @Query("select a from Answer a where a.member = :member and a.question.template.templateType in :templateTypes and a.question.template.job = :job")
     List<Answer> findByMemberAndTemplateTypesAndJob(@Param("member") Member member,
-        @Param("templateTypes") List<TemplateType> templateTypes, @Param("job") Job job);
+                                                    @Param("templateTypes") List<TemplateType> templateTypes, @Param("job") Job job);
 }

--- a/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
+++ b/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
@@ -38,8 +38,8 @@ public class AnswerCommandService {
     }
 
     @Transactional
-    public void updateAnswerList(Member member, AnswerCreateOrUpdateDTO request) {
-        for (AnswerList answerList : request.answerList()) {
+    public void updateAnswerList(Member member, AnswerCreateOrUpdateDTO answerCreateOrUpdateDTO) {
+        for (AnswerList answerList : answerCreateOrUpdateDTO.answerList()) {
             for (AnswerInfo answerInfo : answerList.answerInfoList()) {
                 Question question = questionRepository.findById(answerInfo.questionId())
                         .orElseThrow(() -> new GeneralException(CommonErrorCode.NOT_FOUND_QUESTION));

--- a/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
+++ b/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
@@ -7,7 +7,6 @@ import UMC.career_mate.domain.answer.dto.request.AnswerCreateOrUpdateDTO.AnswerI
 import UMC.career_mate.domain.answer.dto.request.AnswerCreateOrUpdateDTO.AnswerList;
 import UMC.career_mate.domain.answer.repository.AnswerRepository;
 import UMC.career_mate.domain.member.Member;
-import UMC.career_mate.domain.member.repository.MemberRepository;
 import UMC.career_mate.domain.question.Question;
 import UMC.career_mate.domain.question.repository.QuestionRepository;
 import UMC.career_mate.global.response.exception.GeneralException;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnswerCommandService {
     private final AnswerRepository answerRepository;
     private final QuestionRepository questionRepository;
-    private final MemberRepository memberRepository;
 
     @Transactional
     public void saveAnswerList(Member member, AnswerCreateOrUpdateDTO answerCreateOrUpdateDTO) {

--- a/src/main/java/UMC/career_mate/domain/answer/service/AnswerQueryService.java
+++ b/src/main/java/UMC/career_mate/domain/answer/service/AnswerQueryService.java
@@ -24,7 +24,7 @@ public class AnswerQueryService {
 
     @Transactional(readOnly = true)
     public List<AnswerInfoListDTO> getAnswersByTemplateType(Member member, TemplateType templateType) {
-        List<Answer> answerList = answerRepository.findByMemberAndTemplateType(member, templateType);
+        List<Answer> answerList = answerRepository.findByMemberAndTemplateType(member, member.getJob(), templateType);
 
         // sequence 기준으로 그룹화
         Map<Long, List<Answer>> groupedAnswers = answerList.stream()
@@ -42,7 +42,7 @@ public class AnswerQueryService {
 
         // TemplateType 값들을 순회하면서 각 템플릿의 완료 여부를 확인
         for (TemplateType templateType : TemplateType.values()) {
-            boolean isCompleted = answerRepository.existsByMemberAndTemplateType(member, templateType);
+            boolean isCompleted = answerRepository.existsByMemberAndTemplateType(member, member.getJob(), templateType);
             answerCompletionStatusInfoDTOList.add(AnswerConverter.toAnswerCompletionStatusInfoDTO(templateType, isCompleted));
 
             // 하나라도 미완료 상태가 있으면 전체 진행 상태는 false

--- a/src/main/java/UMC/career_mate/domain/answer/service/AnswerQueryService.java
+++ b/src/main/java/UMC/career_mate/domain/answer/service/AnswerQueryService.java
@@ -7,10 +7,7 @@ import UMC.career_mate.domain.answer.dto.response.AnswerCompletionStatusInfoList
 import UMC.career_mate.domain.answer.dto.response.AnswerInfoListDTO;
 import UMC.career_mate.domain.answer.repository.AnswerRepository;
 import UMC.career_mate.domain.member.Member;
-import UMC.career_mate.domain.member.repository.MemberRepository;
 import UMC.career_mate.domain.template.enums.TemplateType;
-import UMC.career_mate.global.response.exception.GeneralException;
-import UMC.career_mate.global.response.exception.code.CommonErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,13 +21,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AnswerQueryService {
     private final AnswerRepository answerRepository;
-    private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public List<AnswerInfoListDTO> getAnswersByTemplateType(Long memberId, TemplateType templateType) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralException(CommonErrorCode.BAD_REQUEST));
-
+    public List<AnswerInfoListDTO> getAnswersByTemplateType(Member member, TemplateType templateType) {
         List<Answer> answerList = answerRepository.findByMemberAndTemplateType(member, templateType);
 
         // sequence 기준으로 그룹화


### PR DESCRIPTION
## #️⃣ 요약 설명
템플릿 타입에 맞는 커리어 조회 API 수정

## 📝 작업 내용
- `LoginMember` 어노테이션을 사용하여 `Member` 객체를 받아오도록 수정했습니다.
- Answer 조회 시 멤버의 Job 조건 추가  
   - 사용자가 프로필에서 Job을 변경한 경우,  이전 Job에 대한 Answer가 조회되지 않도록  쿼리에 member.job 조건을 추가했습니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
