### PR TITLE
[CMAT-51] fix: 커리어를 작성했을 경우 예외를 던지도록 수정

### DIFF
--- a/src/main/java/UMC/career_mate/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/UMC/career_mate/domain/answer/repository/AnswerRepository.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+    Integer countByQuestionId(Long questionId);
 
     @Query("""
                     SELECT a FROM Answer a

--- a/src/main/java/UMC/career_mate/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/UMC/career_mate/domain/answer/repository/AnswerRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
-    Integer countByQuestionId(Long questionId);
+    Long countByQuestionId(Long questionId);
 
     @Query("""
                     SELECT a FROM Answer a

--- a/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
+++ b/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
@@ -28,6 +28,8 @@ public class AnswerCommandService {
     private final QuestionRepository questionRepository;
     private final S3Uploader s3Uploader;
 
+    private static final int MAX_ANSWERS_PER_QUESTION = 2;
+
     @Transactional
     public void saveAnswerList(Member member, AnswerCreateOrUpdateDTO answerCreateOrUpdateDTO, List<MultipartFile> imageFileList) throws IOException {
         // 이미지 업로드 및 URL 저장
@@ -63,14 +65,15 @@ public class AnswerCommandService {
     }
 
     private void validateAnswerLimit(Long questionId) {
-        Integer existingAnswerCount = answerRepository.countByQuestionId(questionId);
-        if (existingAnswerCount >= 2) {
+        Long existingAnswerCount = answerRepository.countByQuestionId(questionId);
+        if (existingAnswerCount >= MAX_ANSWERS_PER_QUESTION) {
             throw new GeneralException(CommonErrorCode.ALREADY_SAVE_ANSWER);
         }
     }
 
     @Transactional
-    public void updateAnswerList(Member member, AnswerCreateOrUpdateDTO answerCreateOrUpdateDTO, List<MultipartFile> imageFileList) throws IOException {
+    public void updateAnswerList(Member member, AnswerCreateOrUpdateDTO
+            answerCreateOrUpdateDTO, List<MultipartFile> imageFileList) throws IOException {
         // 이미지 업로드 및 URL 저장
         List<String> imageUrlList = new ArrayList<>();
         if (imageFileList != null && !imageFileList.isEmpty()) {

--- a/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
+++ b/src/main/java/UMC/career_mate/domain/answer/service/AnswerCommandService.java
@@ -3,11 +3,10 @@ package UMC.career_mate.domain.answer.service;
 import UMC.career_mate.domain.answer.Answer;
 import UMC.career_mate.domain.answer.converter.AnswerConverter;
 import UMC.career_mate.domain.answer.dto.request.AnswerCreateOrUpdateDTO;
-import UMC.career_mate.domain.answer.dto.request.AnswerCreateOrUpdateDTO.AnswerInfoDTO;
 import UMC.career_mate.domain.answer.dto.request.AnswerCreateOrUpdateDTO.AnswerGroupDTO;
+import UMC.career_mate.domain.answer.dto.request.AnswerCreateOrUpdateDTO.AnswerInfoDTO;
 import UMC.career_mate.domain.answer.repository.AnswerRepository;
 import UMC.career_mate.domain.member.Member;
-import UMC.career_mate.domain.member.repository.MemberRepository;
 import UMC.career_mate.domain.question.Question;
 import UMC.career_mate.domain.question.repository.QuestionRepository;
 import UMC.career_mate.global.response.exception.GeneralException;
@@ -28,7 +27,6 @@ public class AnswerCommandService {
     private final AnswerRepository answerRepository;
     private final QuestionRepository questionRepository;
     private final S3Uploader s3Uploader;
-    private final MemberRepository memberRepository;
 
     @Transactional
     public void saveAnswerList(Member member, AnswerCreateOrUpdateDTO answerCreateOrUpdateDTO, List<MultipartFile> imageFileList) throws IOException {
@@ -50,6 +48,8 @@ public class AnswerCommandService {
                 Question question = questionRepository.findById(answerInfo.questionId())
                         .orElseThrow(() -> new GeneralException(CommonErrorCode.NOT_FOUND_QUESTION));
 
+                validateAnswerLimit(question.getId());
+
                 // 특정 질문에 대해서만 이미지 URL 저장
                 String content = (assignedImageUrl != null && question.getId().equals(103L))
                         ? assignedImageUrl
@@ -59,6 +59,13 @@ public class AnswerCommandService {
                 answerRepository.save(answer);
             }
             sequence++;
+        }
+    }
+
+    private void validateAnswerLimit(Long questionId) {
+        Integer existingAnswerCount = answerRepository.countByQuestionId(questionId);
+        if (existingAnswerCount >= 2) {
+            throw new GeneralException(CommonErrorCode.ALREADY_SAVE_ANSWER);
         }
     }
 

--- a/src/main/java/UMC/career_mate/global/response/exception/code/CommonErrorCode.java
+++ b/src/main/java/UMC/career_mate/global/response/exception/code/CommonErrorCode.java
@@ -45,7 +45,7 @@ public enum CommonErrorCode implements ErrorCode {
 
     // Answer 도메인
     NOT_FOUND_ANSWER(400, "EAN000", "해당 답변을 찾을 수 없습니다."),
-    TOO_MANY_ANSWERS(400, "EAN001", "커리어는 두개 이상 작성할 수 없습니다."),
+    ALREADY_SAVE_ANSWER(400, "EAN001", "이미 해당 커리어를 작성했습니다."),
 
     // ContentScrap 도메인
     NOT_FOUND_CONTENT(400, "ESC001", "해당 콘텐츠를 찾을 수 없습니다."),


### PR DESCRIPTION
## #️⃣ 요약 설명
커리어를 작성했을 경우 예외를 던지도록 수정

## 📝 작업 내용
커리어를 작성했을 경우 예외를 던지도록 수정했습니다.

## 동작 확인
![스크린샷 2025-02-03 오전 12 30 45](https://github.com/user-attachments/assets/d083c7a4-bbd8-49b2-a8a6-3ad3480dcba6)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 질문 당 답변 제출 제한 기능이 추가되어, 두 건 이상의 답변 제출 시 추가 등록이 차단됩니다.
	- 제한 초과 시 사용자에게 보다 명확한 안내 메시지가 제공되어, 답변 제출 과정이 개선되었습니다.
	- 특정 질문에 대한 답변 수를 계산하는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->