### PR TITLE
[CMAT-53] fix: 프론트 요청에 따라 컨텐츠 isScrapped로 통일 수정

### DIFF
--- a/src/main/java/UMC/career_mate/domain/contentScrap/converter/ContentScrapConverter.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/converter/ContentScrapConverter.java
@@ -20,7 +20,7 @@ public class ContentScrapConverter {
                 .title(scrap.getContent().getTitle())
                 .url(scrap.getContent().getUrl())
                 .photo(scrap.getContent().getPhoto())
-                .isScraped(true) //isScraped 값이 참인 것들을 가져옵니다.
+                .isScrapped(true) //isScrapped 값이 참인 것들을 가져옵니다.
                 .build();
     }
 }

--- a/src/main/java/UMC/career_mate/domain/contentScrap/dto/response/ContentScrapResponseDTO.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/dto/response/ContentScrapResponseDTO.java
@@ -8,6 +8,6 @@ public record ContentScrapResponseDTO(
         String title,
         String url,
         String photo,
-        boolean isScraped
+        boolean isScrapped
 ) {
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

## 📝 작업 내용

프론트에서 컨텐츠와 컨텐츠 스크랩의 스크랩 여부 항목의 이름을 isScrapped로 통일해달라는 요청이 들어와, isScrapped로 통일하여 수정하였습니다.

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 콘텐츠 스크랩 상태 표시 항목의 명칭을 일관되게 수정하여 데이터 해석의 명료성과 시스템 안정성을 개선했습니다. 내부 처리 방식이 보완되어 관련 기능의 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->