### PR TITLE
[CMAT-54] fix: Planner Entity에서 1000자를 입력 받을 수 있도록 수정

### DIFF
--- a/src/main/java/UMC/career_mate/domain/planner/Planner.java
+++ b/src/main/java/UMC/career_mate/domain/planner/Planner.java
@@ -32,22 +32,22 @@ public class Planner extends BaseEntity {
     @Column(name = "end_time")
     private LocalDateTime endTime;
 
-    @Column
+    @Column(length = 1000)
     private String specifics;
 
-    @Column
+    @Column(length = 1000)
     private String measurable;
 
-    @Column
+    @Column(length = 1000)
     private String achievable;
 
-    @Column
+    @Column(length = 1000)
     private String relevant;
 
-    @Column(name = "time_bound")
+    @Column(length = 1000, name = "time_bound")
     private String timeBound;
 
-    @Column(name = "other_plans")
+    @Column(length = 1000, name = "other_plans")
     private String otherPlans;
 
     @ManyToOne


### PR DESCRIPTION
## #️⃣ 요약 설명
Planner Entity에서 1000자를 입력 받을 수 있도록 수정했습니다

## 📝 작업 내용

Column들에 1000자 제한을 추가했습니다.
```java
@Column(length = 1000)
```

일반 String으로 설정하면 VARCHAR(255)로 들어간다는 사실을 알게 되었습니다.

DB 설정도 직접 바꿨습니다.

## 동작 확인

프런트와 실시간 확인 완료했습니다.

## 💬 리뷰 요구사항(선택)

감사합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
	- 기획 입력 필드의 문자 입력 허용량을 확장하여, 보다 상세하고 풍부한 계획 정보를 기록할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->