### PR TITLE
[CMAT-57] feat: 프론트 RecruitKeyword 상세화

### DIFF
--- a/src/main/java/UMC/career_mate/domain/chatgpt/service/ChatGptService.java
+++ b/src/main/java/UMC/career_mate/domain/chatgpt/service/ChatGptService.java
@@ -1,6 +1,7 @@
 package UMC.career_mate.domain.chatgpt.service;
 
 import UMC.career_mate.domain.chatgpt.dto.api.response.ChatCompletionResponse;
+import UMC.career_mate.domain.job.Job;
 import UMC.career_mate.domain.recruit.dto.MemberTemplateAnswerDTO;
 import UMC.career_mate.domain.chatgpt.dto.api.request.GptRequest;
 import UMC.career_mate.domain.chatgpt.dto.api.request.GptRequest.Message;
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,10 +36,16 @@ public class ChatGptService {
         "이 사람의 경력을 계산해서 앞뒤 설명 하지말고 정수로만 올바른 답변 예시와 같은 형식으로 답변해줘. " +
             "올바론 답변 예시) 5, 잘못된 답변 예시 1) 5년, 잘못된 답변 예시 2) 5 years, 잘못된 답변 예시 3) 이 사람의 경력은 5년";
 
-    private static final String GPT_REQUEST_FORMAT_POSTFIX_FOR_RECRUIT_KEYWORD =
+    private static final String GPT_REQUEST_FORMAT_POSTFIX_FOR_RECRUIT_KEYWORD_BACKEND =
         "이 사람의 직무를 내가 제시한 보기들 중에서 하나만 골라서 답변해줘.\n" +
-            "직무 보기 :'BACKEND', 'BACKEND_SPRING', 'BACKEND_NODE', 'BACKEND_DJANGO', 'FRONTEND', 'DESIGNER', 'PM', " +
-            "이 중에서 적절한 직무가 없다면 'MISMATCH'로 답변해줘.\n" +
+            "직무 보기 :'BACKEND_SPRING', 'BACKEND_NODE', 'BACKEND_DJANGO'. " +
+            "이 중에서 적절한 직무를 고르기 애매하면 'BACKEND'로 답변해줘.\n" +
+            "앞뒤 설명하지 말고 직무만 답변해줘.";
+
+    private static final String GPT_REQUEST_FORMAT_POSTFIX_FOR_RECRUIT_KEYWORD_FRONTEND =
+        "이 사람의 직무를 내가 제시한 보기들 중에서 하나만 골라서 답변해줘.\n" +
+            "직무 보기 : 'FRONTEND_REACT', 'FRONTEND_IOS', 'FRONTEND_ANDROID'. " +
+            "이 중에서 적절한 직무를 고르기 애매하면 'FRONTEND'로 답변해줘.\n" +
             "앞뒤 설명하지 말고 직무만 답변해줘.";
 
     private static final String GPT_REQUEST_FORMAT_FOR_COMMENT =
@@ -45,6 +53,11 @@ public class ChatGptService {
             "친근한 말투로 어떤 포지션이 어울리는지, 어떤 경험을 어필하면 좋을지와 같은 내용으로 조언 문구를 생성해서 답변해줘. " +
             "답변은 문구만 답변해줘. 문구를 생성할 때 내용에는 회사 이름은 제외해줘. " +
             "답변에서 '-'는 빼줘.";
+
+    private static final Map<String, String> formatMap = Map.ofEntries(
+        Map.entry("백엔드 개발자", GPT_REQUEST_FORMAT_POSTFIX_FOR_RECRUIT_KEYWORD_BACKEND),
+        Map.entry("프론트엔드 개발자", GPT_REQUEST_FORMAT_POSTFIX_FOR_RECRUIT_KEYWORD_FRONTEND)
+    );
 
     private static final String GPT_SYSTEM_ROLE = "너는 취업 전문가로서 내가 보낸 경험 데이터를 기반으로 '~~한 경험이 있는 000님, ~~한 경험을 어필해보면 어때요?' 라는 느낌으로 사용자 맞춤형 추천 문구를 작성한다. " +
         "문구의 말투는 '-니다'체를 사용하는 것이 아니라, '-요'체를 사용한다.";
@@ -61,9 +74,9 @@ public class ChatGptService {
         return Integer.parseInt(gptAnswer);
     }
 
-    public RecruitKeyword getRecruitKeyword(String chatGptRequestContent) {
+    public RecruitKeyword getRecruitKeyword(String chatGptRequestContent, Job job) {
         GptRequest gptRequest = createGptRequest(
-            chatGptRequestContent + GPT_REQUEST_FORMAT_POSTFIX_FOR_RECRUIT_KEYWORD);
+            chatGptRequestContent + formatMap.get(job.getName()));
 
         ObjectMapper om = new ObjectMapper();
         String gptAnswer = getGptAnswer(om, gptRequest);

--- a/src/main/java/UMC/career_mate/domain/recruit/enums/RecruitKeyword.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/enums/RecruitKeyword.java
@@ -25,7 +25,7 @@ public enum RecruitKeyword {
 
         @Override
         public List<String> getExcludeKeywordList() {
-            return List.of("Node", "Node.js", "NODE", "javascript", "Python", "Django", "C++", "PHP");
+            return List.of("Node", "Node.js", "NODE", "javascript", "Python", "Django", "C++", "PHP", "C#");
         }
     },
     BACKEND_NODE {
@@ -36,7 +36,7 @@ public enum RecruitKeyword {
 
         @Override
         public List<String> getExcludeKeywordList() {
-            return List.of("java", "JAVA", "spring", "Spring", "SPRING", "Python", "Django", "C++", "PHP");
+            return List.of("java", "JAVA", "spring", "Spring", "SPRING", "Python", "Django", "C++", "PHP", "C#");
         }
     },
     BACKEND_DJANGO {
@@ -48,13 +48,46 @@ public enum RecruitKeyword {
         @Override
         public List<String> getExcludeKeywordList() {
             return List.of("java", "JAVA", "spring", "Spring", "SPRING", "javascript", "Node",
-                "Node.js", "NODE", "C++", "PHP");
+                "Node.js", "NODE", "C++", "PHP", "C#");
         }
     },
     FRONTEND {
         @Override
         public List<String> getIncludeKeywordList() {
             return List.of("Front", "FRONT", "Frontend", "Front-end", "프론트엔드", "프론트");
+        }
+
+        @Override
+        public List<String> getExcludeKeywordList() {
+            return null;
+        }
+    },
+    FRONTEND_REACT {
+        @Override
+        public List<String> getIncludeKeywordList() {
+            return List.of("react");
+        }
+
+        @Override
+        public List<String> getExcludeKeywordList() {
+            return null;
+        }
+    },
+    FRONTEND_IOS {
+        @Override
+        public List<String> getIncludeKeywordList() {
+            return List.of("ios");
+        }
+
+        @Override
+        public List<String> getExcludeKeywordList() {
+            return null;
+        }
+    },
+    FRONTEND_ANDROID {
+        @Override
+        public List<String> getIncludeKeywordList() {
+            return List.of("android");
         }
 
         @Override

--- a/src/main/java/UMC/career_mate/domain/recruit/service/RecruitQueryService.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/service/RecruitQueryService.java
@@ -167,6 +167,11 @@ public class RecruitQueryService {
     private RecruitKeyword calculateRecruitKeyword(Member member) {
         Job job = member.getJob();
 
+        // pm, 디자이너는 gpt 요청 x (상세 직무 나눌 필요 없음)
+        if (job.getName().equals("PM(Product/Project Manager)") || job.getName().equals("Designer")) {
+            return RecruitKeyword.getRecruitKeywordFromProfileJob(job);
+        }
+
         // 프로젝트 템플릿의 답변, 인턴 템플릿의 답변을 가져온다.
         Map<TemplateType, List<Answer>> templateTypeByAnswers = getTemplateTypeByAnswers(
             member, job);
@@ -192,7 +197,7 @@ public class RecruitQueryService {
             return RecruitKeyword.getRecruitKeywordFromProfileJob(job);
         }
 
-        RecruitKeyword recruitKeyword = chatGptService.getRecruitKeyword(contentBuilder.toString());
+        RecruitKeyword recruitKeyword = chatGptService.getRecruitKeyword(contentBuilder.toString(), member.getJob());
 
         if (Objects.isNull(recruitKeyword)) {
             log.info("gpt 답변이 RecruitKeyword에 없는 값이라서 null인 경우 -> 멤버 프로필 job으로 대체");


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

1. RecruitKeyword에서 프론트엔드에 대해 React, iOS, Android를 추가했습니다.
2. PM, 디자이너인 경우 상세 직무를 나눌 필요가 없기 때문에, gpt 요청 로직 없이 프로필 Job으로 바로 RecruitKeyword 변환 값을 사용하도록 수정했습니다.
4. gpt 요청 포맷 내용을 백엔드와 프론트엔드 두개로 분리했습니다.

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

간단한거라서 로컬 테스트로 확인했습니다~

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

이번 업데이트에서는 다양한 직무별 맞춤 키워드 매칭 기능이 강화되어, 사용자 프로필을 기반으로 보다 정교한 결과를 제공합니다. 프론트엔드와 백엔드 직군에 대해 구체적인 필터링 기준이 반영되었으며, PM과 디자이너 직무에 대해서는 신속한 처리 로직이 적용되었습니다.

- **새로운 기능**
	- 다양한 직무(프론트엔드, 백엔드 등)에 맞춘 맞춤형 요청 형식과 키워드 매칭 기능 추가
- **개선 사항**
	- 키워드 필터링 기준 정교화로 일관되고 빠른 매칭 결과 제공
	- PM, 디자이너 직군에 대한 처리 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->