### PR TITLE
[CMAT-58] feat: RecruitScrap 엔티티에 jobName 필드 추가

### DIFF
--- a/src/main/java/UMC/career_mate/domain/recruit/converter/RecruitConverter.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/converter/RecruitConverter.java
@@ -60,13 +60,13 @@ public class RecruitConverter {
             .build();
     }
 
-    public static RecruitThumbNailInfoDTO toRecruitThumbNailInfoDTO(Recruit recruit, boolean isScraped) {
+    public static RecruitThumbNailInfoDTO toRecruitThumbNailInfoDTO(Recruit recruit, boolean isScrapped) {
         return RecruitThumbNailInfoDTO.builder()
             .recruitId(recruit.getId())
             .companyName(recruit.getCompanyName())
             .title(recruit.getTitle())
             .deadLine(formatDeadLine(recruit))
-            .isScraped(isScraped)
+            .isScrapped(isScrapped)
             .experienceLevelCode(recruit.getExperienceLevelCode())
             .experienceLevelMin(recruit.getExperienceLevelMin())
             .experienceLevelMax(recruit.getExperienceLevelMax())

--- a/src/main/java/UMC/career_mate/domain/recruit/dto/response/RecommendRecruitsDTO.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/dto/response/RecommendRecruitsDTO.java
@@ -16,7 +16,7 @@ public record RecommendRecruitsDTO(
         String companyName,
         String title,
         String deadLine,
-        boolean isScraped,
+        boolean isScrapped,
 
         /**
          * TODO: 아래로는 (필터링, 정렬) 잘 되는지 확인용 데이터, 나중에 삭제 예정

--- a/src/main/java/UMC/career_mate/domain/recruit/service/RecruitQueryService.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/service/RecruitQueryService.java
@@ -267,12 +267,12 @@ public class RecruitQueryService {
     }
 
     private PageResponseDTO<RecommendRecruitsDTO> createPageResponseDTO(Page<Recruit> findRecruitPage, Member member) {
-        Set<Long> scrapedRecruitIds = recruitScrapRepository.findRecruitIdsByMember(member);
+        Set<Long> scrappedRecruitIds = recruitScrapRepository.findRecruitIdsByMember(member);
 
         RecommendRecruitsDTO recommendRecruitsDTO = RecruitConverter.toRecommendRecruitsDTO(member,
             findRecruitPage.stream()
                 .map(recruit -> RecruitConverter.toRecruitThumbNailInfoDTO(recruit,
-                    scrapedRecruitIds.contains(recruit.getId())))
+                    scrappedRecruitIds.contains(recruit.getId())))
                 .toList());
 
         return PageResponseDTO.<RecommendRecruitsDTO>builder()

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/RecruitScrap.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/RecruitScrap.java
@@ -28,4 +28,6 @@ public class RecruitScrap extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recruit_id")
     private Recruit recruit;
+
+    private String jobName;
 }

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/controller/RecruitScrapController.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/controller/RecruitScrapController.java
@@ -7,8 +7,6 @@ import UMC.career_mate.domain.recruitScrap.service.RecruitScrapQueryService;
 import UMC.career_mate.global.annotation.LoginMember;
 import UMC.career_mate.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import java.util.List;
-
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -60,9 +58,7 @@ public class RecruitScrapController {
             로그인 인증만을 요구합니다.
             """)
     @GetMapping
-    public ApiResponse<List<RecruitScrapResponseDTO>> getRecruitScrapList(
-        @LoginMember Member member) {
+    public ApiResponse<RecruitScrapResponseDTO> getRecruitScrapList(@LoginMember Member member) {
         return ApiResponse.onSuccess(recruitScrapQueryService.findRecruitScrapList(member));
     }
-
 }

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/converter/RecruitScrapConverter.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/converter/RecruitScrapConverter.java
@@ -23,7 +23,7 @@ public class RecruitScrapConverter {
             .companyName(recruitScrap.getRecruit().getCompanyName())
             .title(recruitScrap.getRecruit().getTitle())
             .deadLine(formatDeadLine(recruitScrap.getRecruit()))
-            .isScraped(true)
+            .isScrapped(true)
             .jobName(recruitScrap.getJobName())
             .build();
     }

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/converter/RecruitScrapConverter.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/converter/RecruitScrapConverter.java
@@ -13,19 +13,18 @@ public class RecruitScrapConverter {
         return RecruitScrap.builder()
             .member(member)
             .recruit(recruit)
+            .jobName(member.getJob().getName())
             .build();
     }
 
-    public static RecruitScrapResponseDTO toRecruitScrapResponseDTO(Recruit recruit, String jobName) {
+    public static RecruitScrapResponseDTO toRecruitScrapResponseDTO(RecruitScrap recruitScrap) {
         return RecruitScrapResponseDTO.builder()
-            .recruitId(recruit.getId())
-            .companyName(recruit.getCompanyName())
-            .title(recruit.getTitle())
-            .deadLine(formatDeadLine(recruit))
+            .recruitId(recruitScrap.getRecruit().getId())
+            .companyName(recruitScrap.getRecruit().getCompanyName())
+            .title(recruitScrap.getRecruit().getTitle())
+            .deadLine(formatDeadLine(recruitScrap.getRecruit()))
             .isScraped(true)
-            .companyInfoUrl(recruit.getCompanyInfoUrl())
-            .recruitUrl(recruit.getRecruitUrl())
-            .jobName(jobName)
+            .jobName(recruitScrap.getJobName())
             .build();
     }
 

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/converter/RecruitScrapConverter.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/converter/RecruitScrapConverter.java
@@ -1,11 +1,14 @@
 package UMC.career_mate.domain.recruitScrap.converter;
 
+import UMC.career_mate.domain.job.Job;
 import UMC.career_mate.domain.member.Member;
 import UMC.career_mate.domain.recruit.Recruit;
 import UMC.career_mate.domain.recruitScrap.RecruitScrap;
 import UMC.career_mate.domain.recruitScrap.dto.response.RecruitScrapResponseDTO;
+import UMC.career_mate.domain.recruitScrap.dto.response.RecruitScrapResponseDTO.RecruitScrapThumbNailInfoDTO;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 public class RecruitScrapConverter {
 
@@ -17,14 +20,28 @@ public class RecruitScrapConverter {
             .build();
     }
 
-    public static RecruitScrapResponseDTO toRecruitScrapResponseDTO(RecruitScrap recruitScrap) {
+    public static RecruitScrapResponseDTO toRecruitScrapResponseDTO(Job job,
+        List<RecruitScrapThumbNailInfoDTO> recruitScrapThumbNailInfoDTOList) {
         return RecruitScrapResponseDTO.builder()
+            .jobName(job.getName())
+            .recruitScrapThumbNailInfoDTOList(recruitScrapThumbNailInfoDTOList)
+            .build();
+    }
+
+    public static RecruitScrapThumbNailInfoDTO toRecruitScrapThumbNailInfoDTO(RecruitScrap recruitScrap) {
+        return RecruitScrapThumbNailInfoDTO.builder()
             .recruitId(recruitScrap.getRecruit().getId())
             .companyName(recruitScrap.getRecruit().getCompanyName())
             .title(recruitScrap.getRecruit().getTitle())
             .deadLine(formatDeadLine(recruitScrap.getRecruit()))
             .isScrapped(true)
-            .jobName(recruitScrap.getJobName())
+            .build();
+    }
+
+    public static RecruitScrapResponseDTO toEmptyRecruitScrapResponseDTO(Job job) {
+        return RecruitScrapResponseDTO.builder()
+            .jobName(job.getName())
+            .recruitScrapThumbNailInfoDTOList(List.of())
             .build();
     }
 

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/dto/response/RecruitScrapResponseDTO.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/dto/response/RecruitScrapResponseDTO.java
@@ -9,7 +9,7 @@ public record RecruitScrapResponseDTO(
     String companyName,
     String title,
     String deadLine,
-    boolean isScraped,
+    boolean isScrapped,
     String jobName
 ) {
 

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/dto/response/RecruitScrapResponseDTO.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/dto/response/RecruitScrapResponseDTO.java
@@ -10,8 +10,6 @@ public record RecruitScrapResponseDTO(
     String title,
     String deadLine,
     boolean isScraped,
-    String companyInfoUrl,
-    String recruitUrl,
     String jobName
 ) {
 

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/dto/response/RecruitScrapResponseDTO.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/dto/response/RecruitScrapResponseDTO.java
@@ -1,16 +1,21 @@
 package UMC.career_mate.domain.recruitScrap.dto.response;
 
-import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record RecruitScrapResponseDTO(
-    Long recruitId,
-    String companyName,
-    String title,
-    String deadLine,
-    boolean isScrapped,
-    String jobName
+    String jobName,
+    List<RecruitScrapThumbNailInfoDTO> recruitScrapThumbNailInfoDTOList
 ) {
 
+    @Builder
+    public record RecruitScrapThumbNailInfoDTO(
+        Long recruitId,
+        String companyName,
+        String title,
+        String deadLine,
+        boolean isScrapped
+        ){
+    }
 }

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/repository/RecruitScrapRepository.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/repository/RecruitScrapRepository.java
@@ -16,8 +16,8 @@ public interface RecruitScrapRepository extends JpaRepository<RecruitScrap, Long
 
     Optional<RecruitScrap> findByMemberAndRecruitId(Member member, Long recruitId);
 
-    @Query("select rs from RecruitScrap rs join fetch rs.recruit where rs.member = :member")
-    List<RecruitScrap> findByMember(@Param("member") Member member);
+    @Query("select rs from RecruitScrap rs join fetch rs.recruit where rs.member = :member and rs.jobName = :jobName")
+    List<RecruitScrap> findByMemberAndJobName(@Param("member") Member member, @Param("jobName") String jobName);
 
     @Query("select rs.recruit.id from RecruitScrap rs where rs.member = :member")
     Set<Long> findRecruitIdsByMember(@Param("member") Member member);

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/service/RecruitScrapQueryService.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/service/RecruitScrapQueryService.java
@@ -1,9 +1,11 @@
 package UMC.career_mate.domain.recruitScrap.service;
 
+import UMC.career_mate.domain.job.Job;
 import UMC.career_mate.domain.member.Member;
 import UMC.career_mate.domain.recruitScrap.RecruitScrap;
 import UMC.career_mate.domain.recruitScrap.converter.RecruitScrapConverter;
 import UMC.career_mate.domain.recruitScrap.dto.response.RecruitScrapResponseDTO;
+import UMC.career_mate.domain.recruitScrap.dto.response.RecruitScrapResponseDTO.RecruitScrapThumbNailInfoDTO;
 import UMC.career_mate.domain.recruitScrap.repository.RecruitScrapRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -17,15 +19,20 @@ public class RecruitScrapQueryService {
 
     private final RecruitScrapRepository recruitScrapRepository;
 
-    public List<RecruitScrapResponseDTO> findRecruitScrapList(Member member) {
-        List<RecruitScrap> recruitScrapList = recruitScrapRepository.findByMember(member);
+    public RecruitScrapResponseDTO findRecruitScrapList(Member member) {
+        Job job = member.getJob();
+        List<RecruitScrap> recruitScrapList = recruitScrapRepository.findByMemberAndJobName(member,
+            job.getName());
 
         if (recruitScrapList.isEmpty()) {
-            return List.of();
+            return RecruitScrapConverter.toEmptyRecruitScrapResponseDTO(job);
         }
 
-        return recruitScrapList.stream()
-            .map(RecruitScrapConverter::toRecruitScrapResponseDTO)
+        List<RecruitScrapThumbNailInfoDTO> recruitScrapThumbNailInfoDTOList = recruitScrapList.stream()
+            .map(RecruitScrapConverter::toRecruitScrapThumbNailInfoDTO)
             .toList();
+
+        return RecruitScrapConverter.toRecruitScrapResponseDTO(job,
+            recruitScrapThumbNailInfoDTOList);
     }
 }

--- a/src/main/java/UMC/career_mate/domain/recruitScrap/service/RecruitScrapQueryService.java
+++ b/src/main/java/UMC/career_mate/domain/recruitScrap/service/RecruitScrapQueryService.java
@@ -25,9 +25,7 @@ public class RecruitScrapQueryService {
         }
 
         return recruitScrapList.stream()
-            .map(RecruitScrap::getRecruit)
-            .map(recruit -> RecruitScrapConverter.toRecruitScrapResponseDTO(recruit,
-                member.getJob().getName()))
+            .map(RecruitScrapConverter::toRecruitScrapResponseDTO)
             .toList();
     }
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

1. 사용자가 프로필 job을 바꾸고 다른 직무의 공고를 스크랩한 경우 직무에 맞는 공고 반환을 위해 jobName 필드를 추가했습니다
2. isScraped 필드명을 isScrapped로 수정했습니다.

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 채용 스크랩 정보에 작업명(job name)이 추가되어, 구직 관련 세부 정보를 더 명확하게 확인할 수 있습니다.
	- 스크랩 응답 구조가 단일 객체로 변경되어, 보다 간편한 데이터 처리가 가능해졌습니다.

- **리팩터**
	- 스크랩 상태를 나타내는 명칭을 일관되게 개선하고, 불필요한 URL 정보 항목을 제거하여 응답 구조를 간소화했습니다.
	- 데이터 변환 프로세스를 최적화하여 전반적인 처리 효율을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->