### PR TITLE
[CMAT-60] fix: 스크랩한 컨텐츠 조회에서 현재 직무와 같은 컨텐츠만 조회되도록 수정

### DIFF
--- a/src/main/java/UMC/career_mate/domain/contentScrap/repository/ContentScrapRepository.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/repository/ContentScrapRepository.java
@@ -19,4 +19,8 @@ public interface ContentScrapRepository extends JpaRepository<ContentScrap, Long
     //회원이 스크랩한 컨텐츠를 모두 조회
     @Query("SELECT cs FROM ContentScrap cs WHERE cs.member = :member")
     List<ContentScrap> findByMember(@Param("member") Member member);
+
+    //회원이 스크랩한 컨텐츠를 현재 직무 기준 같은 것 조회
+    @Query("SELECT cs FROM ContentScrap cs JOIN FETCH cs.content c WHERE cs.member = :member AND c.job.id = :jobId")
+    Page<ContentScrap> findByMemberAndJobId(@Param("member") Member member, @Param("jobId") Long jobId, Pageable pageable);
 }

--- a/src/main/java/UMC/career_mate/domain/contentScrap/service/ContentScrapService.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/service/ContentScrapService.java
@@ -52,8 +52,17 @@ public class ContentScrapService {
 
     @Transactional(readOnly = true)
     public PageResponseDTO<List<ContentScrapResponseDTO>> getScrapContents(Member member, int page, int size) {
+
+        // 로그인한 사용자의 직무 ID 확인
+        Long jobId = member.getJob().getId();
+        if (jobId == null) {
+            throw new GeneralException(CommonErrorCode.NOT_FOUND_BY_JOB_ID);
+        }
+
         PageRequest pageRequest = PageRequest.of(page - 1, size);
-        Page<ContentScrap> scraps = contentScrapRepository.findByMember(member, pageRequest);
+
+        // 로그인한 사용자가 스크랩한 콘텐츠 중 현재 직무 ID와 일치하는 것만 필터링
+        Page<ContentScrap> scraps = contentScrapRepository.findByMemberAndJobId(member, jobId, pageRequest);
 
         List<ContentScrapResponseDTO> contentList = scraps.stream()
                 .map(ContentScrapConverter::toContentScrapResponseDTO)


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

## 📝 작업 내용

1. 이전에 사용자가 스크랩한 모든 컨텐츠를 조회하는 것에서, 스크랩한 컨텐츠들 중 현재 직무 정보와 같은 컨텐츠들만 조회되도록 수정하였습니다.

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 멤버 관련 채용 ID를 기준으로 콘텐츠 스크랩 조회 기능이 개선되었습니다. 페이지네이션을 통해 결과를 쉽게 확인할 수 있습니다.
  - 지원 직무 정보 누락 시 명확한 오류 메시지가 제공되어 보다 안정적인 사용자 경험을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->