### PR TITLE
[CMAT-62] fix: Recruit 스키마 수정, 공고 조회 일부 로직 추가, 불필요 반환값 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,6 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
-	//JSON 타입 사용
-	implementation 'io.hypersistence:hypersistence-utils-hibernate-62:3.7.0'
-
 	//queryDsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/src/main/java/UMC/career_mate/domain/recruit/Recruit.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/Recruit.java
@@ -1,16 +1,12 @@
 package UMC.career_mate.domain.recruit;
 
-import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
-
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Type;
 
 @Entity
 @Table(name = "recruits")
@@ -45,9 +41,8 @@ public class Recruit {
     private String employmentName; // 고용(근무) 형태 값
     private String salaryName; // 연봉 값
 
-    @Type(JsonType.class)
-    @Column(columnDefinition = "json")
-    private List<String> jobNames; // 직무 키워드
+    @Column(columnDefinition = "TEXT")
+    private String hashtags; // 직무 키워드
 
     private String region; // 근무 지역
     private String industryName; // 산업군

--- a/src/main/java/UMC/career_mate/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/controller/RecruitController.java
@@ -31,8 +31,8 @@ public class RecruitController {
     private final RecruitQueryService recruitQueryService;
 
     @Operation(
-            summary = "추천 채용 공고 조회 API",
-            description = """
+        summary = "추천 채용 공고 조회 API",
+        description = """
             추천 채용 공고를 조회하는 API입니다.\n\n
             page의 값은 1부터 시작이고, 기본 값은 1입니다.\n\n
             size의 기본값은 6입니다.\n\n
@@ -43,26 +43,26 @@ public class RecruitController {
             """)
     @GetMapping
     public ApiResponse<PageResponseDTO<RecommendRecruitsDTO>> getRecommendRecruitList(
-            @RequestParam(defaultValue = "1", required = false) int page,
-            @RequestParam(defaultValue = "6", required = false) int size,
-            @RequestParam(defaultValue = "POSTING_DESC", required = false) RecruitSortType recruitSortType,
-            @LoginMember Member member
+        @RequestParam(defaultValue = "1", required = false) int page,
+        @RequestParam(defaultValue = "6", required = false) int size,
+        @RequestParam(defaultValue = "POSTING_DESC", required = false) RecruitSortType recruitSortType,
+        @LoginMember Member member
     ) {
         return ApiResponse.onSuccess(
-                recruitQueryService.getRecommendRecruitList(page, size, recruitSortType, member));
+            recruitQueryService.getRecommendRecruitList(page, size, recruitSortType, member));
     }
 
     @Operation(
-            summary = "채용 공고 요약 페이지 조회 API",
-            description = """
+        summary = "채용 공고 요약 페이지 조회 API",
+        description = """
             채용 공고 요약 페이지를 조회하는 API입니다.\n\n
             recruitId : 조회하려는 채용 공고 pk 값
             """)
     @GetMapping("/{recruitId}")
     public ResponseEntity<ApiResponse<RecruitInfoDTO>> getRecruitInfo(@PathVariable Long recruitId,
-                                                                      @LoginMember Member member) {
+        @LoginMember Member member) {
         return ResponseEntity.ok(
-                ApiResponse.onSuccess(recruitQueryService.findRecruitInfo(member, recruitId)));
+            ApiResponse.onSuccess(recruitQueryService.findRecruitInfo(member, recruitId)));
     }
 
     @Deprecated

--- a/src/main/java/UMC/career_mate/domain/recruit/converter/RecruitConverter.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/converter/RecruitConverter.java
@@ -15,7 +15,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -42,7 +41,7 @@ public class RecruitConverter {
             .educationLevelName(educationLevel.getDescription())
             .employmentName(job.position().jobType().name())
             .salaryName(job.salary().name())
-            .jobNames(Arrays.asList(job.position().jobCode().name()))
+            .hashtags(job.position().jobCode().name())
             .region(StringEscapeUtils.unescapeHtml4(
                 job.position().location().name()))
             .industryName(job.position().industry().name())
@@ -67,13 +66,6 @@ public class RecruitConverter {
             .title(recruit.getTitle())
             .deadLine(formatDeadLine(recruit))
             .isScrapped(isScrapped)
-            .experienceLevelCode(recruit.getExperienceLevelCode())
-            .experienceLevelMin(recruit.getExperienceLevelMin())
-            .experienceLevelMax(recruit.getExperienceLevelMax())
-            .experienceLevelName(recruit.getExperienceLevelName())
-            .educationLevelCode(recruit.getEducationLevelCode())
-            .educationLevelName(recruit.getEducationLevelName())
-            .postingDate(recruit.getPostingDate())
             .build();
     }
 

--- a/src/main/java/UMC/career_mate/domain/recruit/dto/response/RecommendRecruitsDTO.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/dto/response/RecommendRecruitsDTO.java
@@ -1,6 +1,5 @@
 package UMC.career_mate.domain.recruit.dto.response;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
@@ -16,18 +15,7 @@ public record RecommendRecruitsDTO(
         String companyName,
         String title,
         String deadLine,
-        boolean isScrapped,
-
-        /**
-         * TODO: 아래로는 (필터링, 정렬) 잘 되는지 확인용 데이터, 나중에 삭제 예정
-         */
-        Integer experienceLevelCode, // 경력 코드 : 0(경력무관), 1(신입), 2(경력), 3(신입/경력)
-        Integer experienceLevelMin, // 경력 년수 최소 값
-        Integer experienceLevelMax, // 경력 년수 최대 값
-        String experienceLevelName,
-        Integer educationLevelCode, // 학력 코드 0(학력무관), 1(고등학교졸업), 2(대학졸업(2,3년)), 3(대학졸업(4년)), 4(석사졸업), 5(박사졸업) 등
-        String educationLevelName,
-        LocalDateTime postingDate
+        boolean isScrapped
     ) {
 
     }

--- a/src/main/java/UMC/career_mate/domain/recruit/enums/RecruitKeyword.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/enums/RecruitKeyword.java
@@ -7,115 +7,163 @@ public enum RecruitKeyword {
 
     BACKEND {
         @Override
-        public List<String> getIncludeKeywordList() {
-            return List.of("Back", "Backend", "Back-end", "BACK", "백엔드", "서버", "시스템");
+        public List<String> getIncludeTitleKeywordList() {
+            return List.of("Back", "Backend", "Back-end", "백엔드", "서버", "시스템");
         }
 
         @Override
-        public List<String> getExcludeKeywordList() {
+        public List<String> getExcludeTitleKeywordList() {
+            return null;
+        }
+
+        @Override
+        public List<String> getIncludeHashtagKeywordList() {
             return null;
         }
     }
     ,
     BACKEND_SPRING {
         @Override
-        public List<String> getIncludeKeywordList() {
-            return List.of("Back", "Backend", "Back-end", "BACK", "백엔드", "서버", "시스템");
+        public List<String> getIncludeTitleKeywordList() {
+            return List.of("Back", "Backend", "Back-end", "백엔드", "서버", "시스템");
         }
 
         @Override
-        public List<String> getExcludeKeywordList() {
-            return List.of("Node", "Node.js", "NODE", "javascript", "Python", "Django", "C++", "PHP", "C#");
+        public List<String> getExcludeTitleKeywordList() {
+            return List.of("Node", "Node.js", "javascript", "Python", "Django", "C++", "PHP", "C#");
+        }
+
+        @Override
+        public List<String> getIncludeHashtagKeywordList() {
+            return List.of("Spring", "SpringBoot");
         }
     },
     BACKEND_NODE {
         @Override
-        public List<String> getIncludeKeywordList() {
-            return List.of("Back", "Backend", "Back-end", "BACK", "백엔드", "서버", "시스템");
+        public List<String> getIncludeTitleKeywordList() {
+            return List.of("Back", "Backend", "Back-end", "백엔드", "서버", "시스템");
         }
 
         @Override
-        public List<String> getExcludeKeywordList() {
-            return List.of("java", "JAVA", "spring", "Spring", "SPRING", "Python", "Django", "C++", "PHP", "C#");
+        public List<String> getExcludeTitleKeywordList() {
+            return List.of("JAVA", "Spring", "Python", "Django", "C++", "PHP", "C#");
+        }
+
+        @Override
+        public List<String> getIncludeHashtagKeywordList() {
+            return List.of("Node.js");
         }
     },
     BACKEND_DJANGO {
         @Override
-        public List<String> getIncludeKeywordList() {
-            return List.of("Back", "Backend", "Back-end", "BACK", "백엔드", "서버", "시스템");
+        public List<String> getIncludeTitleKeywordList() {
+            return List.of("Back", "Backend", "Back-end", "백엔드", "서버", "시스템");
         }
 
         @Override
-        public List<String> getExcludeKeywordList() {
-            return List.of("java", "JAVA", "spring", "Spring", "SPRING", "javascript", "Node",
-                "Node.js", "NODE", "C++", "PHP", "C#");
+        public List<String> getExcludeTitleKeywordList() {
+            return List.of("JAVA", "Spring", "javascript", "Node", "Node.js", "C++", "PHP", "C#");
+        }
+
+        @Override
+        public List<String> getIncludeHashtagKeywordList() {
+            return List.of("Django", "Python");
         }
     },
     FRONTEND {
         @Override
-        public List<String> getIncludeKeywordList() {
-            return List.of("Front", "FRONT", "Frontend", "Front-end", "프론트엔드", "프론트");
+        public List<String> getIncludeTitleKeywordList() {
+            return List.of("Front", "Frontend", "Front-end", "프론트엔드", "프론트");
         }
 
         @Override
-        public List<String> getExcludeKeywordList() {
+        public List<String> getExcludeTitleKeywordList() {
+            return null;
+        }
+
+        @Override
+        public List<String> getIncludeHashtagKeywordList() {
             return null;
         }
     },
     FRONTEND_REACT {
         @Override
-        public List<String> getIncludeKeywordList() {
-            return List.of("react");
+        public List<String> getIncludeTitleKeywordList() {
+            return List.of("React");
         }
 
         @Override
-        public List<String> getExcludeKeywordList() {
+        public List<String> getExcludeTitleKeywordList() {
             return null;
+        }
+
+        @Override
+        public List<String> getIncludeHashtagKeywordList() {
+            return List.of("React");
         }
     },
     FRONTEND_IOS {
         @Override
-        public List<String> getIncludeKeywordList() {
-            return List.of("ios");
+        public List<String> getIncludeTitleKeywordList() {
+            return List.of("iOS");
         }
 
         @Override
-        public List<String> getExcludeKeywordList() {
+        public List<String> getExcludeTitleKeywordList() {
             return null;
+        }
+
+        @Override
+        public List<String> getIncludeHashtagKeywordList() {
+            return List.of("iOS", "Swift");
         }
     },
     FRONTEND_ANDROID {
         @Override
-        public List<String> getIncludeKeywordList() {
-            return List.of("android");
+        public List<String> getIncludeTitleKeywordList() {
+            return List.of("Android");
         }
 
         @Override
-        public List<String> getExcludeKeywordList() {
+        public List<String> getExcludeTitleKeywordList() {
             return null;
+        }
+
+        @Override
+        public List<String> getIncludeHashtagKeywordList() {
+            return List.of("Android");
         }
     },
     DESIGNER {
         @Override
-        public List<String> getIncludeKeywordList() {
-            return List.of("웹 디자이너", "웹디자이너", "UI", "UX", "디자인", "design", "DESIGN");
+        public List<String> getIncludeTitleKeywordList() {
+            return List.of("웹 디자이너", "웹디자이너", "UI", "UX", "디자인", "design");
         }
 
         @Override
-        public List<String> getExcludeKeywordList() {
-            return List.of("영상디자인", "영상 디자인"); // 굿즈 디자인은? 뺴야하는가
+        public List<String> getExcludeTitleKeywordList() {
+            return List.of("영상디자인", "영상 디자인");
+        }
+
+        @Override
+        public List<String> getIncludeHashtagKeywordList() {
+            return List.of("모바일디자인", "앱디자인", "웹디자인", "UI/UX디자인");
         }
     },
     PM {
         @Override
-        public List<String> getIncludeKeywordList() {
-            return List.of("PM", "Project Manager", "Product Manager", "PROJECT MANAGER",
-                "PRODUCT MANAGER", "프로젝트 매니저", "프로덕트 매니저");
+        public List<String> getIncludeTitleKeywordList() {
+            return List.of("PM", "Project Manager", "Product Manager", "프로젝트 매니저", "프로덕트 매니저");
         }
 
         @Override
-        public List<String> getExcludeKeywordList() {
+        public List<String> getExcludeTitleKeywordList() {
             return null;
+        }
+
+        @Override
+        public List<String> getIncludeHashtagKeywordList() {
+            return List.of("개발PM", "PM(프로젝트매니저)", "PL(프로젝트리더)");
         }
     }
 
@@ -141,6 +189,7 @@ public enum RecruitKeyword {
     }
 
 
-    public abstract List<String> getIncludeKeywordList();
-    public abstract List<String> getExcludeKeywordList();
+    public abstract List<String> getIncludeTitleKeywordList();
+    public abstract List<String> getExcludeTitleKeywordList();
+    public abstract List<String> getIncludeHashtagKeywordList();
 }

--- a/src/main/java/UMC/career_mate/domain/recruit/repository/querydsl/RecruitQueryRepositoryImpl.java
+++ b/src/main/java/UMC/career_mate/domain/recruit/repository/querydsl/RecruitQueryRepositoryImpl.java
@@ -32,12 +32,17 @@ public class RecruitQueryRepositoryImpl implements RecruitQueryRepository {
         Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
 
-        // includeKeywordList에 있는 키워드 중 하나라도 포함되어야 함
-        filterIncludeKeywordList(recruitKeyword.getIncludeKeywordList(), builder);
+        // includeTitleKeywordList에 있는 키워드 중 하나라도 포함되어야 함
+        filterIncludeTitleKeywordList(recruitKeyword.getIncludeTitleKeywordList(), builder);
 
-        // excludeKeywordList에 있는 키워드가 포함되지 않아야 함
-        if (Objects.nonNull(recruitKeyword.getExcludeKeywordList())) {
-            filterExcludeKeywordList(recruitKeyword.getExcludeKeywordList(), builder);
+        // excludeTitleKeywordList에 있는 키워드가 포함되지 않아야 함
+        if (Objects.nonNull(recruitKeyword.getExcludeTitleKeywordList())) {
+            filterExcludeTitleKeywordList(recruitKeyword.getExcludeTitleKeywordList(), builder);
+        }
+
+        // includeHashtagKeywordList에 있는 키워드 중 하나라도 포함되어야 함
+        if (Objects.nonNull(recruitKeyword.getIncludeHashtagKeywordList())) {
+            filterIncludeHashtagKeywordList(recruitKeyword.getIncludeHashtagKeywordList(), builder);
         }
 
         // 학력 필터링
@@ -66,28 +71,42 @@ public class RecruitQueryRepositoryImpl implements RecruitQueryRepository {
         return new PageImpl<>(result, pageable, total);
     }
 
-    private void filterIncludeKeywordList(List<String> includekeywordList, BooleanBuilder builder) {
-        BooleanBuilder includeBuilder = new BooleanBuilder();
+    private void filterIncludeTitleKeywordList(List<String> includekeywordList, BooleanBuilder builder) {
+        BooleanBuilder includeTitleBuilder = new BooleanBuilder();
         for (String keyword : includekeywordList) {
             if (isEnglish(keyword)) {
-                includeBuilder.or(recruit.title.containsIgnoreCase(keyword));
+                includeTitleBuilder.or(recruit.title.containsIgnoreCase(keyword));
             } else {
-                includeBuilder.or(recruit.title.contains(keyword));
+                includeTitleBuilder.or(recruit.title.contains(keyword));
             }
         }
-        builder.and(includeBuilder);
+        builder.and(includeTitleBuilder);
     }
 
-    private void filterExcludeKeywordList(List<String> excludeKeywordList, BooleanBuilder builder) {
-        BooleanBuilder excludeBuilder = new BooleanBuilder();
+    private void filterExcludeTitleKeywordList(List<String> excludeKeywordList, BooleanBuilder builder) {
+        BooleanBuilder excludeTitleBuilder = new BooleanBuilder();
         for (String keyword : excludeKeywordList) {
             if (isEnglish(keyword)) {
-                excludeBuilder.or(recruit.title.containsIgnoreCase(keyword));
+                excludeTitleBuilder.or(recruit.title.containsIgnoreCase(keyword));
             } else {
-                excludeBuilder.or(recruit.title.contains(keyword));
+                excludeTitleBuilder.or(recruit.title.contains(keyword));
             }
         }
-        builder.and(excludeBuilder.not());
+        builder.and(excludeTitleBuilder.not());
+    }
+
+    private void filterIncludeHashtagKeywordList(List<String> includeHashTagKeywordList,
+        BooleanBuilder builder) {
+        BooleanBuilder includeHashtagBuilder = new BooleanBuilder();
+        for (String keyword : includeHashTagKeywordList) {
+            if (isEnglish(keyword)) {
+                includeHashtagBuilder.or(recruit.hashtags.containsIgnoreCase(keyword));
+            } else {
+                includeHashtagBuilder.or(recruit.hashtags.contains(keyword));
+            }
+        }
+
+        builder.and(includeHashtagBuilder);
     }
 
     private void filterEducation(EducationLevel educationLevel, BooleanBuilder builder) {


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

1. Recruit 엔티티의 필드명(jobNames -> hashtags)과 데이터 타입(Json -> TEXT)을 수정했습니다.
2. 채용 공고 조회 쿼리에 hashtags 값에 대한 조건도 추가했습니다.
3. 값 정렬과 조회가 잘 되는지 확인용으로 반환했던 필드들을 삭제했습니다.

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 불필요한 라이브러리 의존성을 제거하여 빌드 구성을 정리했습니다.
- **Refactor**
  - 채용 정보의 직무 키워드가 기존 목록에서 단일 해시태그 문자열로 변경되었습니다.
  - 추천 채용 목록 관련 데이터 구성이 단순화되어 일부 세부 정보가 제거되었습니다.
- **New Features**
  - 키워드 검색 기능이 향상되어, 타이틀 및 해시태그 기반의 필터링이 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->