### PR TITLE
[CMAT-63] fix: 스크랩한 컨텐츠 조회 API 수정

### DIFF
--- a/src/main/java/UMC/career_mate/domain/contentScrap/dto/response/ContentScrapResponseDTO.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/dto/response/ContentScrapResponseDTO.java
@@ -8,6 +8,7 @@ public record ContentScrapResponseDTO(
         String title,
         String url,
         String photo,
+        Long jobId,
         boolean isScrapped
 ) {
 }

--- a/src/main/java/UMC/career_mate/domain/contentScrap/repository/ContentScrapRepository.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/repository/ContentScrapRepository.java
@@ -20,7 +20,4 @@ public interface ContentScrapRepository extends JpaRepository<ContentScrap, Long
     @Query("SELECT cs FROM ContentScrap cs WHERE cs.member = :member")
     List<ContentScrap> findByMember(@Param("member") Member member);
 
-    //회원이 스크랩한 컨텐츠를 현재 직무 기준 같은 것 조회
-    @Query("SELECT cs FROM ContentScrap cs JOIN FETCH cs.content c WHERE cs.member = :member AND c.job.id = :jobId")
-    Page<ContentScrap> findByMemberAndJobId(@Param("member") Member member, @Param("jobId") Long jobId, Pageable pageable);
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

## 📝 작업 내용

1. 예외 처리 부분에서 JOBID가 아니라 JOB을 기준으로 처리하도록 하였습니다.
2. 사용자의 직무ID와 같은 스크랩한 컨텐츠를 가져올 때 filter() 을 사용해 처리하도록 수정하였습니다.

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 스크랩된 콘텐츠 응답에 직무 관련 식별 정보가 추가되어, 사용자에게 더 풍부한 정보를 제공합니다.
- **리팩토링**
  - 콘텐츠 스크랩 필터링 및 페이징 로직을 개선하여, 결과의 정확성과 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->