### PR TITLE
[CMAT-63] fix: 스크랩한 컨텐츠 조회 api 수정

### DIFF
--- a/src/main/java/UMC/career_mate/domain/content/controller/ContentController.java
+++ b/src/main/java/UMC/career_mate/domain/content/controller/ContentController.java
@@ -109,7 +109,7 @@ public class ContentController {
     @Operation(
             summary = "스크랩한 컨텐츠 조회 API",
             description = """
-                사용자가 스크랩한 컨텐츠를 조회합니다.
+                사용자의 현재 직무 기준 사용자가 스크랩한 컨텐츠를 조회합니다.
                 Query Parameters:
                 - 'page': 페이지 번호 (기본값: 1)
                 - 'size': 페이지 크기 (기본값: 10)

--- a/src/main/java/UMC/career_mate/domain/contentScrap/dto/response/ContentScrapResponseDTO.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/dto/response/ContentScrapResponseDTO.java
@@ -8,7 +8,6 @@ public record ContentScrapResponseDTO(
         String title,
         String url,
         String photo,
-        Long jobId,
         boolean isScrapped
 ) {
 }

--- a/src/main/java/UMC/career_mate/domain/contentScrap/dto/response/ContentScrapResponseDTO.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/dto/response/ContentScrapResponseDTO.java
@@ -8,6 +8,7 @@ public record ContentScrapResponseDTO(
         String title,
         String url,
         String photo,
+        Long jobId,
         boolean isScrapped
 ) {
 }

--- a/src/main/java/UMC/career_mate/domain/contentScrap/repository/ContentScrapRepository.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/repository/ContentScrapRepository.java
@@ -20,7 +20,4 @@ public interface ContentScrapRepository extends JpaRepository<ContentScrap, Long
     @Query("SELECT cs FROM ContentScrap cs WHERE cs.member = :member")
     List<ContentScrap> findByMember(@Param("member") Member member);
 
-    //회원이 스크랩한 컨텐츠를 현재 직무 기준 같은 것 조회
-    @Query("SELECT cs FROM ContentScrap cs JOIN FETCH cs.content c WHERE cs.member = :member AND c.job.id = :jobId")
-    Page<ContentScrap> findByMemberAndJobId(@Param("member") Member member, @Param("jobId") Long jobId, Pageable pageable);
 }

--- a/src/main/java/UMC/career_mate/domain/contentScrap/repository/ContentScrapRepository.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/repository/ContentScrapRepository.java
@@ -20,4 +20,9 @@ public interface ContentScrapRepository extends JpaRepository<ContentScrap, Long
     @Query("SELECT cs FROM ContentScrap cs WHERE cs.member = :member")
     List<ContentScrap> findByMember(@Param("member") Member member);
 
+    @Query("SELECT cs FROM ContentScrap cs " +
+            "JOIN FETCH cs.content c " +
+            "WHERE cs.member = :member AND c.job.id = :jobId")
+    Page<ContentScrap> findByMemberAndJobId(@Param("member") Member member, @Param("jobId") Long jobId, Pageable pageable);
+
 }

--- a/src/main/java/UMC/career_mate/domain/contentScrap/service/ContentScrapService.java
+++ b/src/main/java/UMC/career_mate/domain/contentScrap/service/ContentScrapService.java
@@ -61,18 +61,15 @@ public class ContentScrapService {
 
         PageRequest pageRequest = PageRequest.of(page - 1, size);
 
-        Page<ContentScrap> allScraps = contentScrapRepository.findByMember(member, pageRequest);
+        Page<ContentScrap> scraps = contentScrapRepository.findByMemberAndJobId(member, jobId, pageRequest);
 
-        List<ContentScrapResponseDTO> contentList = allScraps.stream()
-                .filter(scrap -> scrap.getContent().getJob().getId().equals(jobId))
+        List<ContentScrapResponseDTO> contentList = scraps.stream()
                 .map(ContentScrapConverter::toContentScrapResponseDTO)
                 .toList();
 
-        boolean hasNext = allScraps.hasNext();
-
         return PageResponseDTO.<List<ContentScrapResponseDTO>>builder()
                 .page(page)
-                .hasNext(hasNext)
+                .hasNext(scraps.hasNext())
                 .result(contentList)
                 .build();
     }


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

## 📝 작업 내용

1. 예외 처리시 JOBID가 아니라 JOB을 기준으로 하도록 수정하였습니다.
2. 패치 조인으로 가져올 때에 함수를 조금 수정하였습니다.

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 콘텐츠 스크랩 데이터를 불러올 때, 멤버의 작업 정보 누락으로 인한 오류 발생 가능성을 개선했습니다.
    
- **Refactor**
  - 관련 작업 정보를 한 번에 불러올 수 있도록 데이터 조회 방식을 최적화하여 사용자 경험을 더욱 안정적으로 개선했습니다.
  
- **Documentation**
  - API 엔드포인트 설명을 사용자의 현재 직무 기준으로 스크랩한 콘텐츠를 조회하는 내용으로 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->